### PR TITLE
Remove debugger from the gemfile

### DIFF
--- a/hydra-pbcore.gemspec
+++ b/hydra-pbcore.gemspec
@@ -17,16 +17,12 @@ Gem::Specification.new do |gem|
   gem.version       = HydraPbcore::VERSION
 
   # Dependencies
-  gem.add_dependency('nokogiri')
-  gem.add_dependency('om')
   gem.add_dependency('active-fedora')
-  gem.add_dependency('solrizer')
   gem.add_development_dependency('yard')
   gem.add_development_dependency('redcarpet')
   # For Development
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
-  gem.add_development_dependency 'debugger'
   gem.add_development_dependency 'rdoc'
   gem.add_development_dependency 'equivalent-xml'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 # :nodoc
 require "hydra-pbcore"
-require "debugger"
 require "equivalent-xml"
 
 RSpec.configure do |config|


### PR DESCRIPTION
The Travis docs expressly request that we remove debugger from the gemfile to save cycles.   You can always add 'debugger' to the Gemfile when you are doing debugging.
