### PR TITLE
Specifies specific commit for active fedora dependency.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in hydra-pbcore.gemspec
 gemspec
+
+# Only needed until a rubygems release includes 'c39671d', probably '~> 9.0.8'.
+# Once that happens, remove this line.
+gem 'active-fedora', github: 'projecthydra/active_fedora', ref: 'c39671d'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # :nodoc
+require 'rspec/matchers'
 require "hydra-pbcore"
 require "equivalent-xml"
 require "pry"


### PR DESCRIPTION
Only temporary until new af release includes the patch.
This should help Travis get past the active_fedora bug so we can merge other PRs with confidence.