### PR TITLE
Fixes a bunch of dependency issues along with some code that had to c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HydraPbcore
 
-[![Build Status](https://travis-ci.org/awead/hydra-pbcore.png)](https://travis-ci.org/awead/hydra-pbcore)
+[![Build Status](https://travis-ci.org/projecthydra-labs/hydra-pbcore.png)](https://travis-ci.org/projecthydra-labs/hydra-pbcore)
 [![Gem Version](https://badge.fury.io/rb/hydra-pbcore.png)](http://badge.fury.io/rb/hydra-pbcore)
 
 A Hydra gem that offers PBCore datastream definitions using OM, as well as some other convenience

--- a/hydra-pbcore.gemspec
+++ b/hydra-pbcore.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.version       = HydraPbcore::VERSION
 
   # Dependencies
-  gem.add_dependency('active-fedora')
+  gem.add_dependency('active-fedora', '~> 8.1')
   gem.add_dependency('solrizer')
   gem.add_development_dependency('yard')
   gem.add_development_dependency('redcarpet')
@@ -26,6 +26,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rdoc'
   gem.add_development_dependency 'equivalent-xml'
-  gem.add_development_dependency 'debugger'
   gem.add_development_dependency 'pry'
 end

--- a/lib/hydra-pbcore.rb
+++ b/lib/hydra-pbcore.rb
@@ -4,9 +4,12 @@ require "solrizer"
 require "om"
 require "active-fedora"
 require "yaml"
+require 'logger'
 
 module HydraPbcore
   extend ActiveSupport::Autoload
+
+  attr_accessor :logger
 
   DocumentNodes = [
     "pbcoreAssetType",
@@ -91,6 +94,10 @@ module HydraPbcore
   def self.is_valid? xml
     xsd = Nokogiri::XML::Schema(open("http://pbcore.org/xsd/pbcore-2.0.xsd"))
     xsd.validate(xml)
+  end
+
+  def self.logger
+    @logger ||= Logger.new(STDOUT)
   end
 
   autoload :Methods

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -4,7 +4,8 @@ require "pry"
 describe HydraPbcore::Datastream::Document do
 
   before(:each) do
-    @object_ds = HydraPbcore::Datastream::Document.new(nil, nil)
+    @object_ds = HydraPbcore::Datastream::Document.new(nil, 'test1')
+    @object_ds.pbc_id = 'test-datastream'
   end
 
   describe "::xml_template" do
@@ -54,8 +55,8 @@ describe HydraPbcore::Datastream::Document do
       ].each do |pointer|
         test_val = random_string
         @object_ds.update_values( {pointer=>{"0"=>test_val}} )
-        @object_ds.get_values(pointer).first.should == test_val
-        @object_ds.get_values(pointer).length.should == 1
+        expect(@object_ds.get_values(pointer).first).to eq test_val
+        expect(@object_ds.get_values(pointer).length).to eq 1
       end
     end
 
@@ -73,8 +74,8 @@ describe HydraPbcore::Datastream::Document do
       ].each do |pointer|
         test_val = "#{pointer.last.to_s} value"
         @object_ds.update_indexed_attributes( {pointer=>{"0"=>test_val}} )
-        @object_ds.get_values(pointer).first.should == test_val
-        @object_ds.get_values(pointer).length.should == 1
+        expect(@object_ds.get_values(pointer).first).to eq test_val
+        expect(@object_ds.get_values(pointer).length).to eq 1
       end
     end
 
@@ -82,23 +83,23 @@ describe HydraPbcore::Datastream::Document do
       it "includes archival colletions" do
         @object_ds = HydraPbcore::Datastream::Document.new(nil, nil)
         @object_ds.is_part_of("My Collection", {:annotation => 'Archival Collection'})
-        @object_ds.collection.should == ['My Collection']
+        expect(@object_ds.collection).to eq ['My Collection']
       end
       it "includes event series" do
         @object_ds.is_part_of("My event", {:annotation => 'Event Series'})
-        @object_ds.series.should == ['My event']
+        expect(@object_ds.series).to eq ['My event']
       end
       it "includes archival series" do
         @object_ds.is_part_of("My series", {:annotation => 'Archival Series'})
-        @object_ds.archival_series.should == ['My series']
+        expect(@object_ds.archival_series).to eq ['My series']
       end
       it "includes accession numbers" do
         @object_ds.is_part_of("My Acces Num", {:annotation => 'Accession Number'})
-        @object_ds.accession_number.should == ['My Acces Num']
+        expect(@object_ds.accession_number).to eq ['My Acces Num']
       end
       it "includes additional colletions" do
         @object_ds.is_part_of("Some other collection", {:annotation => 'Additional Collection'})
-        @object_ds.additional_collection.should == ['Some other collection']
+        expect(@object_ds.additional_collection).to eq ['Some other collection']
       end
     end
 
@@ -106,11 +107,11 @@ describe HydraPbcore::Datastream::Document do
     it "should differentiate between multiple added nodes" do
       @object_ds.insert_contributor("first contributor", "first contributor role")
       @object_ds.insert_contributor("second contributor", "second contributor role")
-      @object_ds.get_values(:contributor).length.should == 2
-      @object_ds.get_values(:contributor_name)[0].should == "first contributor"
-      @object_ds.get_values(:contributor_name)[1].should == "second contributor"
-      @object_ds.get_values(:contributor_role)[0].should == "first contributor role"
-      @object_ds.get_values(:contributor_role)[1].should == "second contributor role"
+      expect(@object_ds.get_values(:contributor).length).to eq 2
+      expect(@object_ds.get_values(:contributor_name)[0]).to eq "first contributor"
+      expect(@object_ds.get_values(:contributor_name)[1]).to eq "second contributor"
+      expect(@object_ds.get_values(:contributor_role)[0]).to eq "first contributor role"
+      expect(@object_ds.get_values(:contributor_role)[1]).to eq "second contributor role"
     end
   end
 
@@ -119,11 +120,11 @@ describe HydraPbcore::Datastream::Document do
       ["publisher", "contributor"].each do |type|
         @object_ds.send("insert_"+type)
         @object_ds.send("insert_"+type)
-        @object_ds.find_by_terms(type.to_sym).count.should == 2
+        expect(@object_ds.find_by_terms(type.to_sym).count).to eq 2
         @object_ds.remove_node(type.to_sym, "1")
-        @object_ds.find_by_terms(type.to_sym).count.should == 1
+        expect(@object_ds.find_by_terms(type.to_sym).count).to eq 1
         @object_ds.remove_node(type.to_sym, "0")
-        @object_ds.find_by_terms(type.to_sym).count.should == 0
+        expect(@object_ds.find_by_terms(type.to_sym).count).to eq 0
       end
     end
   end
@@ -179,15 +180,15 @@ describe HydraPbcore::Datastream::Document do
 
     describe "solr dates" do
       it "should be indexed for display" do
-        @object_ds.to_solr["event_date_ssm"].should == ["2012-11-11", "2012-11-12"]
+        expect(@object_ds.to_solr["test1__event_date_ssm"]).to eq ["2012-11-11", "2012-11-12"]
       end
 
       it "should be converted to ISO 8601" do
-        @object_ds.to_solr["event_date_dtsim"].should == ["2012-11-11T00:00:00Z", "2012-11-12T00:00:00Z"]
+        expect(@object_ds.to_solr["test1__event_date_dtsim"]).to eq ["2012-11-11T00:00:00Z", "2012-11-12T00:00:00Z"]
       end
 
       it "should not be searchable as strings" do
-        @object_ds.to_solr["event_date_t"].should be_nil
+        expect(@object_ds.to_solr["test1__event_date_t"]).to be_nil
       end
     end
 
@@ -198,7 +199,7 @@ describe HydraPbcore::Datastream::Document do
 
     it "xml document should validate against the PBCore schema" do
       save_template @object_ds.to_pbcore_xml, "document_valid.xml"
-      @object_ds.valid?.should == []
+      expect(@object_ds.valid?).to eq []
     end
 
     describe "xml document with instantiations" do
@@ -212,7 +213,7 @@ describe HydraPbcore::Datastream::Document do
 
       it "should validate against the PBCore schema" do
         save_template @object_ds.to_pbcore_xml([@digital, @physical]), "document_with_instantiations_valid.xml"
-        expect(HydraPbcore.is_valid?(Nokogiri::XML(sample("document_with_instantiations_valid.xml")))).to eq true
+        expect(HydraPbcore.is_valid?(Nokogiri::XML(sample("document_with_instantiations_valid.xml")))).to eq []
       end
 
     end
@@ -222,43 +223,43 @@ describe HydraPbcore::Datastream::Document do
   describe "solrization" do
 
     before :each do
-      @ds = HydraPbcore::Datastream::Document.new(nil, nil)
+      @ds = HydraPbcore::Datastream::Document.new(nil, 'test1')
     end
 
     it "should not create duplicate terms for contributor fields" do
       @ds.insert_contributor("foo", "bar")
-      @ds.to_solr["contributor_name_sim"].should == ["foo"]
+      expect(@ds.to_solr["test1__contributor_name_sim"]).to eq ["foo"]
     end
 
     it "should not create duplicate terms for creator fields" do
       @ds.insert_creator("foo", "bar")
-      @ds.to_solr["creator_name_sim"].should == ["foo"]
+      expect(@ds.to_solr["test1__creator_name_sim"]).to eq ["foo"]
     end
 
     describe "of dates" do
 
       it "creates dateable and displayable fields for complete dates" do
         @ds.insert_date("1898-11-12")
-        @ds.to_solr["event_date_dtsim"].should == ["1898-11-12T00:00:00Z"]
-        @ds.to_solr["event_date_ssm"].should == ["1898-11-12"]
+        expect(@ds.to_solr["test1__event_date_dtsim"]).to eq ["1898-11-12T00:00:00Z"]
+        expect(@ds.to_solr["test1__event_date_ssm"]).to eq ["1898-11-12"]
       end
 
       it "creates only displayable fields for dates without day" do
         @ds.insert_date("1911-07")
-        @ds.to_solr["event_date_dtsim"].should be_empty
-        @ds.to_solr["event_date_ssm"].should == ["1911-07"]
+        expect(@ds.to_solr["test1__event_date_dtsim"]).to eq []
+        expect(@ds.to_solr["test1__event_date_ssm"]).to eq ["1911-07"]
       end
 
       it "creates only displayable fields for dates without day and month" do
         @ds.insert_date("1945")
-        @ds.to_solr["event_date_dtsim"].should be_empty
-        @ds.to_solr["event_date_ssm"].should == ["1945"]
+        expect(@ds.to_solr["test1__event_date_dtsim"]).to eq []
+        expect(@ds.to_solr["test1__event_date_ssm"]).to eq ["1945"]
       end
 
       it "creates only displayable for non-parseable dates" do
         @ds.insert_date("crap")
-        @ds.to_solr["event_date_dtsim"].should be_empty
-        @ds.to_solr["event_date_ssm"].should == ["crap"]
+        expect(@ds.to_solr["test1__event_date_dtsim"]).to eq []
+        expect(@ds.to_solr["test1__event_date_ssm"]).to eq ["crap"]
       end
 
     end
@@ -268,15 +269,15 @@ describe HydraPbcore::Datastream::Document do
   describe "#collection_uri" do
     it "should return the uri of the collection" do
       @object_ds.is_part_of("Collection", {:annotation => "Archival Collection", :ref => "http://foo"})
-      @object_ds.collection.should == ["Collection"]
-      @object_ds.collection_uri.should == ["http://foo"]
+      expect(@object_ds.collection).to eq ["Collection"]
+      expect(@object_ds.collection_uri).to eq ["http://foo"]
     end
     it "should update the uri of a collection" do
       @object_ds.is_part_of("Collection", {:annotation => "Archival Collection"})
-      expect(@object_ds.collection_uri).to be_empty
+      expect(@object_ds.collection_uri).to eq []
       @object_ds.relation.collection.uri = "http://foo"
       expect(@object_ds.collection_uri).to eq ["http://foo"]
-      expect(@object_ds).to be_valid
+      expect(@object_ds.valid?).to eq []
     end
   end
 
@@ -291,7 +292,7 @@ describe HydraPbcore::Datastream::Document do
       expect(@object_ds.collection_authority).to be_empty
       @object_ds.relation.collection.authority = "Foo!"
       expect(@object_ds.collection_authority).to eq ["Foo!"]
-      expect(@object_ds).to be_valid
+      expect(@object_ds.valid?).to eq []
     end
   end
 
@@ -303,25 +304,27 @@ describe HydraPbcore::Datastream::Document do
     end
     it "should update the uri of a archival_series" do
       @object_ds.is_part_of("Series", {:annotation => "Archival Series"})
-      expect(@object_ds.archival_series_uri).to be_empty
+      expect(@object_ds.archival_series_uri).to eq []
       @object_ds.relation.series.uri = "http://foo"
       expect(@object_ds.archival_series_uri).to eq ["http://foo"]
-      expect(@object_ds).to be_valid
+      expect(@object_ds.valid?).to eq []
     end
   end
 
   describe "#archival_series_authority" do
+    
     it "should return the authority of the archival_series" do
       @object_ds.is_part_of("Series", {:annotation => "Archival Series", :source => "Foo"})
       expect(@object_ds.archival_series).to eq ["Series"]
       expect(@object_ds.archival_series_authority).to eq ["Foo"]
     end
+
     it "should update the authority of a archival_series" do
       @object_ds.is_part_of("Series", {:annotation => "Archival Series"})
       expect(@object_ds.archival_series_authority).to be_empty
       @object_ds.relation.series.authority = "Foo!"
       expect(@object_ds.archival_series_authority).to eq ["Foo!"]
-      expect(@object_ds).to be_valid
+      expect(@object_ds.valid?).to eq []
     end
   end
 

--- a/spec/fixtures/digital_instantiation_solr.xml
+++ b/spec/fixtures/digital_instantiation_solr.xml
@@ -1,416 +1,416 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hash>
-  <name-ssm type="array">
-    <name-ssm>name</name-ssm>
-  </name-ssm>
-  <instantiationDate-dtsim type="array">
-    <instantiationDate-dtsim>2012-11-01T00:00:00Z</instantiationDate-dtsim>
-  </instantiationDate-dtsim>
-  <instantiationDate-ssm type="array">
-    <instantiationDate-ssm>2012-11-01</instantiationDate-ssm>
-  </instantiationDate-ssm>
-  <instantiationDigital-teim type="array">
-    <instantiationDigital-teim>file_format</instantiationDigital-teim>
-  </instantiationDigital-teim>
-  <instantiationDigital-ssm type="array">
-    <instantiationDigital-ssm>file_format</instantiationDigital-ssm>
-  </instantiationDigital-ssm>
-  <instantiationDigital-sim type="array">
-    <instantiationDigital-sim>file_format</instantiationDigital-sim>
-  </instantiationDigital-sim>
-  <instantiationLocation-ssm type="array">
-    <instantiationLocation-ssm>location</instantiationLocation-ssm>
-  </instantiationLocation-ssm>
-  <instantiationGenerations-ssm type="array">
-    <instantiationGenerations-ssm>generation</instantiationGenerations-ssm>
-  </instantiationGenerations-ssm>
-  <instantiationFileSize-ssm type="array">
-    <instantiationFileSize-ssm>size</instantiationFileSize-ssm>
-  </instantiationFileSize-ssm>
-  <instantiationFileSize-units-ssm type="array">
-    <instantiationFileSize-units-ssm>size_units</instantiationFileSize-units-ssm>
-  </instantiationFileSize-units-ssm>
-  <instantiationFileSize-0-units-ssm type="array">
-    <instantiationFileSize-0-units-ssm>size_units</instantiationFileSize-0-units-ssm>
-  </instantiationFileSize-0-units-ssm>
-  <instantiationColors-ssm type="array">
-    <instantiationColors-ssm>colors</instantiationColors-ssm>
-  </instantiationColors-ssm>
-  <instantiationMediaType-ssm type="array">
-    <instantiationMediaType-ssm>media_type</instantiationMediaType-ssm>
-  </instantiationMediaType-ssm>
-  <instantiationMediaType-sim type="array">
-    <instantiationMediaType-sim>media_type</instantiationMediaType-sim>
-  </instantiationMediaType-sim>
-  <instantiationDuration-ssm type="array">
-    <instantiationDuration-ssm>duration</instantiationDuration-ssm>
-  </instantiationDuration-ssm>
-  <instantiationRights-rightsSummary-ssm type="array">
-    <instantiationRights-rightsSummary-ssm>rights_summary</instantiationRights-rightsSummary-ssm>
-  </instantiationRights-rightsSummary-ssm>
-  <instantiationRights-0-rightsSummary-ssm type="array">
-    <instantiationRights-0-rightsSummary-ssm>rights_summary</instantiationRights-0-rightsSummary-ssm>
-  </instantiationRights-0-rightsSummary-ssm>
-  <instantiationEssenceTrack-essenceTrackStandard-ssm type="array">
-    <instantiationEssenceTrack-essenceTrackStandard-ssm>video_standard</instantiationEssenceTrack-essenceTrackStandard-ssm>
-    <instantiationEssenceTrack-essenceTrackStandard-ssm>audio_standard</instantiationEssenceTrack-essenceTrackStandard-ssm>
-  </instantiationEssenceTrack-essenceTrackStandard-ssm>
-  <instantiationEssenceTrack-0-essenceTrackStandard-ssm type="array">
-    <instantiationEssenceTrack-0-essenceTrackStandard-ssm>video_standard</instantiationEssenceTrack-0-essenceTrackStandard-ssm>
-  </instantiationEssenceTrack-0-essenceTrackStandard-ssm>
-  <instantiationEssenceTrack-essenceTrackEncoding-ssm type="array">
-    <instantiationEssenceTrack-essenceTrackEncoding-ssm>video_encoding</instantiationEssenceTrack-essenceTrackEncoding-ssm>
-    <instantiationEssenceTrack-essenceTrackEncoding-ssm>audio_encoding</instantiationEssenceTrack-essenceTrackEncoding-ssm>
-  </instantiationEssenceTrack-essenceTrackEncoding-ssm>
-  <instantiationEssenceTrack-0-essenceTrackEncoding-ssm type="array">
-    <instantiationEssenceTrack-0-essenceTrackEncoding-ssm>video_encoding</instantiationEssenceTrack-0-essenceTrackEncoding-ssm>
-  </instantiationEssenceTrack-0-essenceTrackEncoding-ssm>
-  <instantiationEssenceTrack-essenceTrackDataRate-ssm type="array">
-    <instantiationEssenceTrack-essenceTrackDataRate-ssm>video_bit_rate</instantiationEssenceTrack-essenceTrackDataRate-ssm>
-    <instantiationEssenceTrack-essenceTrackDataRate-ssm>audio_bit_rate</instantiationEssenceTrack-essenceTrackDataRate-ssm>
-  </instantiationEssenceTrack-essenceTrackDataRate-ssm>
-  <instantiationEssenceTrack-0-essenceTrackDataRate-ssm type="array">
-    <instantiationEssenceTrack-0-essenceTrackDataRate-ssm>video_bit_rate</instantiationEssenceTrack-0-essenceTrackDataRate-ssm>
-  </instantiationEssenceTrack-0-essenceTrackDataRate-ssm>
-  <instantiationEssenceTrack-essenceTrackDataRate-units-ssm type="array">
-    <instantiationEssenceTrack-essenceTrackDataRate-units-ssm>video_bit_rate_units</instantiationEssenceTrack-essenceTrackDataRate-units-ssm>
-    <instantiationEssenceTrack-essenceTrackDataRate-units-ssm>audio_bit_rate_units</instantiationEssenceTrack-essenceTrackDataRate-units-ssm>
-  </instantiationEssenceTrack-essenceTrackDataRate-units-ssm>
-  <instantiationEssenceTrack-0-essenceTrackDataRate-0-units-ssm type="array">
-    <instantiationEssenceTrack-0-essenceTrackDataRate-0-units-ssm>video_bit_rate_units</instantiationEssenceTrack-0-essenceTrackDataRate-0-units-ssm>
-  </instantiationEssenceTrack-0-essenceTrackDataRate-0-units-ssm>
-  <instantiationEssenceTrack-essenceTrackFrameRate-ssm type="array">
-    <instantiationEssenceTrack-essenceTrackFrameRate-ssm>frame_rate</instantiationEssenceTrack-essenceTrackFrameRate-ssm>
-  </instantiationEssenceTrack-essenceTrackFrameRate-ssm>
-  <instantiationEssenceTrack-0-essenceTrackFrameRate-ssm type="array">
-    <instantiationEssenceTrack-0-essenceTrackFrameRate-ssm>frame_rate</instantiationEssenceTrack-0-essenceTrackFrameRate-ssm>
-  </instantiationEssenceTrack-0-essenceTrackFrameRate-ssm>
-  <instantiationEssenceTrack-essenceTrackFrameSize-ssm type="array">
-    <instantiationEssenceTrack-essenceTrackFrameSize-ssm>frame_size</instantiationEssenceTrack-essenceTrackFrameSize-ssm>
-  </instantiationEssenceTrack-essenceTrackFrameSize-ssm>
-  <instantiationEssenceTrack-0-essenceTrackFrameSize-ssm type="array">
-    <instantiationEssenceTrack-0-essenceTrackFrameSize-ssm>frame_size</instantiationEssenceTrack-0-essenceTrackFrameSize-ssm>
-  </instantiationEssenceTrack-0-essenceTrackFrameSize-ssm>
-  <instantiationEssenceTrack-essenceTrackBitDepth-ssm type="array">
-    <instantiationEssenceTrack-essenceTrackBitDepth-ssm>video_bit_depth</instantiationEssenceTrack-essenceTrackBitDepth-ssm>
-    <instantiationEssenceTrack-essenceTrackBitDepth-ssm>audio_bit_depth</instantiationEssenceTrack-essenceTrackBitDepth-ssm>
-  </instantiationEssenceTrack-essenceTrackBitDepth-ssm>
-  <instantiationEssenceTrack-0-essenceTrackBitDepth-ssm type="array">
-    <instantiationEssenceTrack-0-essenceTrackBitDepth-ssm>video_bit_depth</instantiationEssenceTrack-0-essenceTrackBitDepth-ssm>
-  </instantiationEssenceTrack-0-essenceTrackBitDepth-ssm>
-  <instantiationEssenceTrack-essenceTrackAspectRatio-ssm type="array">
-    <instantiationEssenceTrack-essenceTrackAspectRatio-ssm>aspect_ratio</instantiationEssenceTrack-essenceTrackAspectRatio-ssm>
-  </instantiationEssenceTrack-essenceTrackAspectRatio-ssm>
-  <instantiationEssenceTrack-0-essenceTrackAspectRatio-ssm type="array">
-    <instantiationEssenceTrack-0-essenceTrackAspectRatio-ssm>aspect_ratio</instantiationEssenceTrack-0-essenceTrackAspectRatio-ssm>
-  </instantiationEssenceTrack-0-essenceTrackAspectRatio-ssm>
-  <instantiationEssenceTrack-1-essenceTrackStandard-ssm type="array">
-    <instantiationEssenceTrack-1-essenceTrackStandard-ssm>audio_standard</instantiationEssenceTrack-1-essenceTrackStandard-ssm>
-  </instantiationEssenceTrack-1-essenceTrackStandard-ssm>
-  <instantiationEssenceTrack-1-essenceTrackEncoding-ssm type="array">
-    <instantiationEssenceTrack-1-essenceTrackEncoding-ssm>audio_encoding</instantiationEssenceTrack-1-essenceTrackEncoding-ssm>
-  </instantiationEssenceTrack-1-essenceTrackEncoding-ssm>
-  <instantiationEssenceTrack-1-essenceTrackDataRate-ssm type="array">
-    <instantiationEssenceTrack-1-essenceTrackDataRate-ssm>audio_bit_rate</instantiationEssenceTrack-1-essenceTrackDataRate-ssm>
-  </instantiationEssenceTrack-1-essenceTrackDataRate-ssm>
-  <instantiationEssenceTrack-1-essenceTrackDataRate-0-units-ssm type="array">
-    <instantiationEssenceTrack-1-essenceTrackDataRate-0-units-ssm>audio_bit_rate_units</instantiationEssenceTrack-1-essenceTrackDataRate-0-units-ssm>
-  </instantiationEssenceTrack-1-essenceTrackDataRate-0-units-ssm>
-  <instantiationEssenceTrack-1-essenceTrackBitDepth-ssm type="array">
-    <instantiationEssenceTrack-1-essenceTrackBitDepth-ssm>audio_bit_depth</instantiationEssenceTrack-1-essenceTrackBitDepth-ssm>
-  </instantiationEssenceTrack-1-essenceTrackBitDepth-ssm>
-  <instantiationEssenceTrack-essenceTrackSamplingRate-ssm type="array">
-    <instantiationEssenceTrack-essenceTrackSamplingRate-ssm>audio_sample_rate</instantiationEssenceTrack-essenceTrackSamplingRate-ssm>
-  </instantiationEssenceTrack-essenceTrackSamplingRate-ssm>
-  <instantiationEssenceTrack-1-essenceTrackSamplingRate-ssm type="array">
-    <instantiationEssenceTrack-1-essenceTrackSamplingRate-ssm>audio_sample_rate</instantiationEssenceTrack-1-essenceTrackSamplingRate-ssm>
-  </instantiationEssenceTrack-1-essenceTrackSamplingRate-ssm>
-  <instantiationEssenceTrack-essenceTrackSamplingRate-units-ssm type="array">
-    <instantiationEssenceTrack-essenceTrackSamplingRate-units-ssm>audio_sample_rate_units</instantiationEssenceTrack-essenceTrackSamplingRate-units-ssm>
-  </instantiationEssenceTrack-essenceTrackSamplingRate-units-ssm>
-  <instantiationEssenceTrack-1-essenceTrackSamplingRate-0-units-ssm type="array">
-    <instantiationEssenceTrack-1-essenceTrackSamplingRate-0-units-ssm>audio_sample_rate_units</instantiationEssenceTrack-1-essenceTrackSamplingRate-0-units-ssm>
-  </instantiationEssenceTrack-1-essenceTrackSamplingRate-0-units-ssm>
-  <instantiationEssenceTrack-essenceTrackAnnotation-ssm type="array">
-    <instantiationEssenceTrack-essenceTrackAnnotation-ssm>audio_channels</instantiationEssenceTrack-essenceTrackAnnotation-ssm>
-  </instantiationEssenceTrack-essenceTrackAnnotation-ssm>
-  <instantiationEssenceTrack-1-essenceTrackAnnotation-ssm type="array">
-    <instantiationEssenceTrack-1-essenceTrackAnnotation-ssm>audio_channels</instantiationEssenceTrack-1-essenceTrackAnnotation-ssm>
-  </instantiationEssenceTrack-1-essenceTrackAnnotation-ssm>
-  <video-essence-essenceTrackStandard-ssm type="array">
-    <video-essence-essenceTrackStandard-ssm>video_standard</video-essence-essenceTrackStandard-ssm>
-  </video-essence-essenceTrackStandard-ssm>
-  <video-essence-0-essenceTrackStandard-ssm type="array">
-    <video-essence-0-essenceTrackStandard-ssm>video_standard</video-essence-0-essenceTrackStandard-ssm>
-  </video-essence-0-essenceTrackStandard-ssm>
-  <video-essence-essenceTrackEncoding-ssm type="array">
-    <video-essence-essenceTrackEncoding-ssm>video_encoding</video-essence-essenceTrackEncoding-ssm>
-  </video-essence-essenceTrackEncoding-ssm>
-  <video-essence-0-essenceTrackEncoding-ssm type="array">
-    <video-essence-0-essenceTrackEncoding-ssm>video_encoding</video-essence-0-essenceTrackEncoding-ssm>
-  </video-essence-0-essenceTrackEncoding-ssm>
-  <video-essence-essenceTrackDataRate-ssm type="array">
-    <video-essence-essenceTrackDataRate-ssm>video_bit_rate</video-essence-essenceTrackDataRate-ssm>
-  </video-essence-essenceTrackDataRate-ssm>
-  <video-essence-0-essenceTrackDataRate-ssm type="array">
-    <video-essence-0-essenceTrackDataRate-ssm>video_bit_rate</video-essence-0-essenceTrackDataRate-ssm>
-  </video-essence-0-essenceTrackDataRate-ssm>
-  <video-essence-essenceTrackDataRate-units-ssm type="array">
-    <video-essence-essenceTrackDataRate-units-ssm>video_bit_rate_units</video-essence-essenceTrackDataRate-units-ssm>
-  </video-essence-essenceTrackDataRate-units-ssm>
-  <video-essence-0-essenceTrackDataRate-0-units-ssm type="array">
-    <video-essence-0-essenceTrackDataRate-0-units-ssm>video_bit_rate_units</video-essence-0-essenceTrackDataRate-0-units-ssm>
-  </video-essence-0-essenceTrackDataRate-0-units-ssm>
-  <video-essence-essenceTrackFrameRate-ssm type="array">
-    <video-essence-essenceTrackFrameRate-ssm>frame_rate</video-essence-essenceTrackFrameRate-ssm>
-  </video-essence-essenceTrackFrameRate-ssm>
-  <video-essence-0-essenceTrackFrameRate-ssm type="array">
-    <video-essence-0-essenceTrackFrameRate-ssm>frame_rate</video-essence-0-essenceTrackFrameRate-ssm>
-  </video-essence-0-essenceTrackFrameRate-ssm>
-  <video-essence-essenceTrackFrameSize-ssm type="array">
-    <video-essence-essenceTrackFrameSize-ssm>frame_size</video-essence-essenceTrackFrameSize-ssm>
-  </video-essence-essenceTrackFrameSize-ssm>
-  <video-essence-0-essenceTrackFrameSize-ssm type="array">
-    <video-essence-0-essenceTrackFrameSize-ssm>frame_size</video-essence-0-essenceTrackFrameSize-ssm>
-  </video-essence-0-essenceTrackFrameSize-ssm>
-  <video-essence-essenceTrackBitDepth-ssm type="array">
-    <video-essence-essenceTrackBitDepth-ssm>video_bit_depth</video-essence-essenceTrackBitDepth-ssm>
-  </video-essence-essenceTrackBitDepth-ssm>
-  <video-essence-0-essenceTrackBitDepth-ssm type="array">
-    <video-essence-0-essenceTrackBitDepth-ssm>video_bit_depth</video-essence-0-essenceTrackBitDepth-ssm>
-  </video-essence-0-essenceTrackBitDepth-ssm>
-  <video-essence-essenceTrackAspectRatio-ssm type="array">
-    <video-essence-essenceTrackAspectRatio-ssm>aspect_ratio</video-essence-essenceTrackAspectRatio-ssm>
-  </video-essence-essenceTrackAspectRatio-ssm>
-  <video-essence-0-essenceTrackAspectRatio-ssm type="array">
-    <video-essence-0-essenceTrackAspectRatio-ssm>aspect_ratio</video-essence-0-essenceTrackAspectRatio-ssm>
-  </video-essence-0-essenceTrackAspectRatio-ssm>
-  <audio-essence-essenceTrackStandard-ssm type="array">
-    <audio-essence-essenceTrackStandard-ssm>audio_standard</audio-essence-essenceTrackStandard-ssm>
-  </audio-essence-essenceTrackStandard-ssm>
-  <audio-essence-0-essenceTrackStandard-ssm type="array">
-    <audio-essence-0-essenceTrackStandard-ssm>audio_standard</audio-essence-0-essenceTrackStandard-ssm>
-  </audio-essence-0-essenceTrackStandard-ssm>
-  <audio-essence-essenceTrackEncoding-ssm type="array">
-    <audio-essence-essenceTrackEncoding-ssm>audio_encoding</audio-essence-essenceTrackEncoding-ssm>
-  </audio-essence-essenceTrackEncoding-ssm>
-  <audio-essence-0-essenceTrackEncoding-ssm type="array">
-    <audio-essence-0-essenceTrackEncoding-ssm>audio_encoding</audio-essence-0-essenceTrackEncoding-ssm>
-  </audio-essence-0-essenceTrackEncoding-ssm>
-  <audio-essence-essenceTrackDataRate-ssm type="array">
-    <audio-essence-essenceTrackDataRate-ssm>audio_bit_rate</audio-essence-essenceTrackDataRate-ssm>
-  </audio-essence-essenceTrackDataRate-ssm>
-  <audio-essence-0-essenceTrackDataRate-ssm type="array">
-    <audio-essence-0-essenceTrackDataRate-ssm>audio_bit_rate</audio-essence-0-essenceTrackDataRate-ssm>
-  </audio-essence-0-essenceTrackDataRate-ssm>
-  <audio-essence-essenceTrackDataRate-units-ssm type="array">
-    <audio-essence-essenceTrackDataRate-units-ssm>audio_bit_rate_units</audio-essence-essenceTrackDataRate-units-ssm>
-  </audio-essence-essenceTrackDataRate-units-ssm>
-  <audio-essence-0-essenceTrackDataRate-0-units-ssm type="array">
-    <audio-essence-0-essenceTrackDataRate-0-units-ssm>audio_bit_rate_units</audio-essence-0-essenceTrackDataRate-0-units-ssm>
-  </audio-essence-0-essenceTrackDataRate-0-units-ssm>
-  <audio-essence-essenceTrackBitDepth-ssm type="array">
-    <audio-essence-essenceTrackBitDepth-ssm>audio_bit_depth</audio-essence-essenceTrackBitDepth-ssm>
-  </audio-essence-essenceTrackBitDepth-ssm>
-  <audio-essence-0-essenceTrackBitDepth-ssm type="array">
-    <audio-essence-0-essenceTrackBitDepth-ssm>audio_bit_depth</audio-essence-0-essenceTrackBitDepth-ssm>
-  </audio-essence-0-essenceTrackBitDepth-ssm>
-  <audio-essence-essenceTrackSamplingRate-ssm type="array">
-    <audio-essence-essenceTrackSamplingRate-ssm>audio_sample_rate</audio-essence-essenceTrackSamplingRate-ssm>
-  </audio-essence-essenceTrackSamplingRate-ssm>
-  <audio-essence-0-essenceTrackSamplingRate-ssm type="array">
-    <audio-essence-0-essenceTrackSamplingRate-ssm>audio_sample_rate</audio-essence-0-essenceTrackSamplingRate-ssm>
-  </audio-essence-0-essenceTrackSamplingRate-ssm>
-  <audio-essence-essenceTrackSamplingRate-units-ssm type="array">
-    <audio-essence-essenceTrackSamplingRate-units-ssm>audio_sample_rate_units</audio-essence-essenceTrackSamplingRate-units-ssm>
-  </audio-essence-essenceTrackSamplingRate-units-ssm>
-  <audio-essence-0-essenceTrackSamplingRate-0-units-ssm type="array">
-    <audio-essence-0-essenceTrackSamplingRate-0-units-ssm>audio_sample_rate_units</audio-essence-0-essenceTrackSamplingRate-0-units-ssm>
-  </audio-essence-0-essenceTrackSamplingRate-0-units-ssm>
-  <audio-essence-essenceTrackAnnotation-ssm type="array">
-    <audio-essence-essenceTrackAnnotation-ssm>audio_channels</audio-essence-essenceTrackAnnotation-ssm>
-  </audio-essence-essenceTrackAnnotation-ssm>
-  <audio-essence-0-essenceTrackAnnotation-ssm type="array">
-    <audio-essence-0-essenceTrackAnnotation-ssm>audio_channels</audio-essence-0-essenceTrackAnnotation-ssm>
-  </audio-essence-0-essenceTrackAnnotation-ssm>
-  <inst-chksum-type-ssm type="array">
-    <inst-chksum-type-ssm>checksum_type</inst-chksum-type-ssm>
-  </inst-chksum-type-ssm>
-  <inst-chksum-value-ssm type="array">
-    <inst-chksum-value-ssm>checksum_value</inst-chksum-value-ssm>
-  </inst-chksum-value-ssm>
-  <inst-device-ssm type="array">
-    <inst-device-ssm>device</inst-device-ssm>
-  </inst-device-ssm>
-  <inst-capture-soft-ssm type="array">
-    <inst-capture-soft-ssm>capture_soft</inst-capture-soft-ssm>
-  </inst-capture-soft-ssm>
-  <inst-trans-soft-ssm type="array">
-    <inst-trans-soft-ssm>trans_soft</inst-trans-soft-ssm>
-  </inst-trans-soft-ssm>
-  <inst-operator-ssm type="array">
-    <inst-operator-ssm>operator</inst-operator-ssm>
-  </inst-operator-ssm>
-  <inst-trans-note-ssm type="array">
-    <inst-trans-note-ssm>trans_note</inst-trans-note-ssm>
-  </inst-trans-note-ssm>
-  <inst-vendor-ssm type="array">
-    <inst-vendor-ssm>vendor</inst-vendor-ssm>
-  </inst-vendor-ssm>
-  <inst-cond-note-ssm type="array">
-    <inst-cond-note-ssm>condition</inst-cond-note-ssm>
-  </inst-cond-note-ssm>
-  <inst-clean-note-ssm type="array">
-    <inst-clean-note-ssm>cleaning</inst-clean-note-ssm>
-  </inst-clean-note-ssm>
-  <inst-note-ssm type="array">
-    <inst-note-ssm>note</inst-note-ssm>
-  </inst-note-ssm>
-  <inst-color-space-ssm type="array">
-    <inst-color-space-ssm>color_space</inst-color-space-ssm>
-  </inst-color-space-ssm>
-  <inst-chroma-ssm type="array">
-    <inst-chroma-ssm>chroma</inst-chroma-ssm>
-  </inst-chroma-ssm>
-  <condition-note-teim type="array">
-    <condition-note-teim>condition</condition-note-teim>
-  </condition-note-teim>
-  <condition-note-ssm type="array">
-    <condition-note-ssm>condition</condition-note-ssm>
-  </condition-note-ssm>
-  <cleaning-note-teim type="array">
-    <cleaning-note-teim>cleaning</cleaning-note-teim>
-  </cleaning-note-teim>
-  <cleaning-note-ssm type="array">
-    <cleaning-note-ssm>cleaning</cleaning-note-ssm>
-  </cleaning-note-ssm>
-  <location-ssm type="array">
-    <location-ssm>location</location-ssm>
-  </location-ssm>
-  <date-dtsim type="array">
-    <date-dtsim>2012-11-01T00:00:00Z</date-dtsim>
-  </date-dtsim>
-  <date-ssm type="array">
-    <date-ssm>2012-11-01</date-ssm>
-  </date-ssm>
-  <generation-ssm type="array">
-    <generation-ssm>generation</generation-ssm>
-  </generation-ssm>
-  <media-type-ssm type="array">
-    <media-type-ssm>media_type</media-type-ssm>
-  </media-type-ssm>
-  <media-type-sim type="array">
-    <media-type-sim>media_type</media-type-sim>
-  </media-type-sim>
-  <file-format-teim type="array">
-    <file-format-teim>file_format</file-format-teim>
-  </file-format-teim>
-  <file-format-ssm type="array">
-    <file-format-ssm>file_format</file-format-ssm>
-  </file-format-ssm>
-  <file-format-sim type="array">
-    <file-format-sim>file_format</file-format-sim>
-  </file-format-sim>
-  <size-ssm type="array">
-    <size-ssm>size</size-ssm>
-  </size-ssm>
-  <size-units-ssm type="array">
-    <size-units-ssm>size_units</size-units-ssm>
-  </size-units-ssm>
-  <colors-ssm type="array">
-    <colors-ssm>colors</colors-ssm>
-  </colors-ssm>
-  <duration-ssm type="array">
-    <duration-ssm>duration</duration-ssm>
-  </duration-ssm>
-  <rights-summary-ssm type="array">
-    <rights-summary-ssm>rights_summary</rights-summary-ssm>
-  </rights-summary-ssm>
-  <note-ssm type="array">
-    <note-ssm>note</note-ssm>
-  </note-ssm>
-  <checksum-type-ssm type="array">
-    <checksum-type-ssm>checksum_type</checksum-type-ssm>
-  </checksum-type-ssm>
-  <checksum-value-ssm type="array">
-    <checksum-value-ssm>checksum_value</checksum-value-ssm>
-  </checksum-value-ssm>
-  <device-ssm type="array">
-    <device-ssm>device</device-ssm>
-  </device-ssm>
-  <capture-soft-ssm type="array">
-    <capture-soft-ssm>capture_soft</capture-soft-ssm>
-  </capture-soft-ssm>
-  <trans-soft-ssm type="array">
-    <trans-soft-ssm>trans_soft</trans-soft-ssm>
-  </trans-soft-ssm>
-  <operator-ssm type="array">
-    <operator-ssm>operator</operator-ssm>
-  </operator-ssm>
-  <trans-note-ssm type="array">
-    <trans-note-ssm>trans_note</trans-note-ssm>
-  </trans-note-ssm>
-  <vendor-ssm type="array">
-    <vendor-ssm>vendor</vendor-ssm>
-  </vendor-ssm>
-  <condition-ssm type="array">
-    <condition-ssm>condition</condition-ssm>
-  </condition-ssm>
-  <cleaning-ssm type="array">
-    <cleaning-ssm>cleaning</cleaning-ssm>
-  </cleaning-ssm>
-  <color-space-ssm type="array">
-    <color-space-ssm>color_space</color-space-ssm>
-  </color-space-ssm>
-  <chroma-ssm type="array">
-    <chroma-ssm>chroma</chroma-ssm>
-  </chroma-ssm>
-  <video-standard-ssm type="array">
-    <video-standard-ssm>video_standard</video-standard-ssm>
-  </video-standard-ssm>
-  <video-encoding-ssm type="array">
-    <video-encoding-ssm>video_encoding</video-encoding-ssm>
-  </video-encoding-ssm>
-  <video-bit-rate-ssm type="array">
-    <video-bit-rate-ssm>video_bit_rate</video-bit-rate-ssm>
-  </video-bit-rate-ssm>
-  <video-bit-rate-units-ssm type="array">
-    <video-bit-rate-units-ssm>video_bit_rate_units</video-bit-rate-units-ssm>
-  </video-bit-rate-units-ssm>
-  <frame-rate-ssm type="array">
-    <frame-rate-ssm>frame_rate</frame-rate-ssm>
-  </frame-rate-ssm>
-  <frame-size-ssm type="array">
-    <frame-size-ssm>frame_size</frame-size-ssm>
-  </frame-size-ssm>
-  <video-bit-depth-ssm type="array">
-    <video-bit-depth-ssm>video_bit_depth</video-bit-depth-ssm>
-  </video-bit-depth-ssm>
-  <aspect-ratio-ssm type="array">
-    <aspect-ratio-ssm>aspect_ratio</aspect-ratio-ssm>
-  </aspect-ratio-ssm>
-  <audio-standard-ssm type="array">
-    <audio-standard-ssm>audio_standard</audio-standard-ssm>
-  </audio-standard-ssm>
-  <audio-encoding-ssm type="array">
-    <audio-encoding-ssm>audio_encoding</audio-encoding-ssm>
-  </audio-encoding-ssm>
-  <audio-bit-rate-ssm type="array">
-    <audio-bit-rate-ssm>audio_bit_rate</audio-bit-rate-ssm>
-  </audio-bit-rate-ssm>
-  <audio-bit-rate-units-ssm type="array">
-    <audio-bit-rate-units-ssm>audio_bit_rate_units</audio-bit-rate-units-ssm>
-  </audio-bit-rate-units-ssm>
-  <audio-sample-rate-ssm type="array">
-    <audio-sample-rate-ssm>audio_sample_rate</audio-sample-rate-ssm>
-  </audio-sample-rate-ssm>
-  <audio-sample-rate-units-ssm type="array">
-    <audio-sample-rate-units-ssm>audio_sample_rate_units</audio-sample-rate-units-ssm>
-  </audio-sample-rate-units-ssm>
-  <audio-bit-depth-ssm type="array">
-    <audio-bit-depth-ssm>audio_bit_depth</audio-bit-depth-ssm>
-  </audio-bit-depth-ssm>
-  <audio-channels-ssm type="array">
-    <audio-channels-ssm>audio_channels</audio-channels-ssm>
-  </audio-channels-ssm>
+ <test1--name-ssm type="array">
+   <test1--name-ssm>name</test1--name-ssm>
+ </test1--name-ssm>
+ <test1--instantiationDate-dtsim type="array">
+   <test1--instantiationDate-dtsim>2012-11-01T00:00:00Z</test1--instantiationDate-dtsim>
+ </test1--instantiationDate-dtsim>
+ <test1--instantiationDate-ssm type="array">
+   <test1--instantiationDate-ssm>2012-11-01</test1--instantiationDate-ssm>
+ </test1--instantiationDate-ssm>
+ <test1--instantiationDigital-teim type="array">
+   <test1--instantiationDigital-teim>file_format</test1--instantiationDigital-teim>
+ </test1--instantiationDigital-teim>
+ <test1--instantiationDigital-ssm type="array">
+   <test1--instantiationDigital-ssm>file_format</test1--instantiationDigital-ssm>
+ </test1--instantiationDigital-ssm>
+ <test1--instantiationDigital-sim type="array">
+   <test1--instantiationDigital-sim>file_format</test1--instantiationDigital-sim>
+ </test1--instantiationDigital-sim>
+ <test1--instantiationLocation-ssm type="array">
+   <test1--instantiationLocation-ssm>location</test1--instantiationLocation-ssm>
+ </test1--instantiationLocation-ssm>
+ <test1--instantiationGenerations-ssm type="array">
+   <test1--instantiationGenerations-ssm>generation</test1--instantiationGenerations-ssm>
+ </test1--instantiationGenerations-ssm>
+ <test1--instantiationFileSize-ssm type="array">
+   <test1--instantiationFileSize-ssm>size</test1--instantiationFileSize-ssm>
+ </test1--instantiationFileSize-ssm>
+ <test1--instantiationFileSize-units-ssm type="array">
+   <test1--instantiationFileSize-units-ssm>size_units</test1--instantiationFileSize-units-ssm>
+ </test1--instantiationFileSize-units-ssm>
+ <test1--instantiationFileSize-0-units-ssm type="array">
+   <test1--instantiationFileSize-0-units-ssm>size_units</test1--instantiationFileSize-0-units-ssm>
+ </test1--instantiationFileSize-0-units-ssm>
+ <test1--instantiationColors-ssm type="array">
+   <test1--instantiationColors-ssm>colors</test1--instantiationColors-ssm>
+ </test1--instantiationColors-ssm>
+ <test1--instantiationMediaType-ssm type="array">
+   <test1--instantiationMediaType-ssm>media_type</test1--instantiationMediaType-ssm>
+ </test1--instantiationMediaType-ssm>
+ <test1--instantiationMediaType-sim type="array">
+   <test1--instantiationMediaType-sim>media_type</test1--instantiationMediaType-sim>
+ </test1--instantiationMediaType-sim>
+ <test1--instantiationDuration-ssm type="array">
+   <test1--instantiationDuration-ssm>duration</test1--instantiationDuration-ssm>
+ </test1--instantiationDuration-ssm>
+ <test1--instantiationRights-rightsSummary-ssm type="array">
+   <test1--instantiationRights-rightsSummary-ssm>rights_summary</test1--instantiationRights-rightsSummary-ssm>
+ </test1--instantiationRights-rightsSummary-ssm>
+ <test1--instantiationRights-0-rightsSummary-ssm type="array">
+   <test1--instantiationRights-0-rightsSummary-ssm>rights_summary</test1--instantiationRights-0-rightsSummary-ssm>
+ </test1--instantiationRights-0-rightsSummary-ssm>
+ <test1--instantiationEssenceTrack-essenceTrackStandard-ssm type="array">
+   <test1--instantiationEssenceTrack-essenceTrackStandard-ssm>video_standard</test1--instantiationEssenceTrack-essenceTrackStandard-ssm>
+   <test1--instantiationEssenceTrack-essenceTrackStandard-ssm>audio_standard</test1--instantiationEssenceTrack-essenceTrackStandard-ssm>
+ </test1--instantiationEssenceTrack-essenceTrackStandard-ssm>
+ <test1--instantiationEssenceTrack-0-essenceTrackStandard-ssm type="array">
+   <test1--instantiationEssenceTrack-0-essenceTrackStandard-ssm>video_standard</test1--instantiationEssenceTrack-0-essenceTrackStandard-ssm>
+ </test1--instantiationEssenceTrack-0-essenceTrackStandard-ssm>
+ <test1--instantiationEssenceTrack-essenceTrackEncoding-ssm type="array">
+   <test1--instantiationEssenceTrack-essenceTrackEncoding-ssm>video_encoding</test1--instantiationEssenceTrack-essenceTrackEncoding-ssm>
+   <test1--instantiationEssenceTrack-essenceTrackEncoding-ssm>audio_encoding</test1--instantiationEssenceTrack-essenceTrackEncoding-ssm>
+ </test1--instantiationEssenceTrack-essenceTrackEncoding-ssm>
+ <test1--instantiationEssenceTrack-0-essenceTrackEncoding-ssm type="array">
+   <test1--instantiationEssenceTrack-0-essenceTrackEncoding-ssm>video_encoding</test1--instantiationEssenceTrack-0-essenceTrackEncoding-ssm>
+ </test1--instantiationEssenceTrack-0-essenceTrackEncoding-ssm>
+ <test1--instantiationEssenceTrack-essenceTrackDataRate-ssm type="array">
+   <test1--instantiationEssenceTrack-essenceTrackDataRate-ssm>video_bit_rate</test1--instantiationEssenceTrack-essenceTrackDataRate-ssm>
+   <test1--instantiationEssenceTrack-essenceTrackDataRate-ssm>audio_bit_rate</test1--instantiationEssenceTrack-essenceTrackDataRate-ssm>
+ </test1--instantiationEssenceTrack-essenceTrackDataRate-ssm>
+ <test1--instantiationEssenceTrack-0-essenceTrackDataRate-ssm type="array">
+   <test1--instantiationEssenceTrack-0-essenceTrackDataRate-ssm>video_bit_rate</test1--instantiationEssenceTrack-0-essenceTrackDataRate-ssm>
+ </test1--instantiationEssenceTrack-0-essenceTrackDataRate-ssm>
+ <test1--instantiationEssenceTrack-essenceTrackDataRate-units-ssm type="array">
+   <test1--instantiationEssenceTrack-essenceTrackDataRate-units-ssm>video_bit_rate_units</test1--instantiationEssenceTrack-essenceTrackDataRate-units-ssm>
+   <test1--instantiationEssenceTrack-essenceTrackDataRate-units-ssm>audio_bit_rate_units</test1--instantiationEssenceTrack-essenceTrackDataRate-units-ssm>
+ </test1--instantiationEssenceTrack-essenceTrackDataRate-units-ssm>
+ <test1--instantiationEssenceTrack-0-essenceTrackDataRate-0-units-ssm type="array">
+   <test1--instantiationEssenceTrack-0-essenceTrackDataRate-0-units-ssm>video_bit_rate_units</test1--instantiationEssenceTrack-0-essenceTrackDataRate-0-units-ssm>
+ </test1--instantiationEssenceTrack-0-essenceTrackDataRate-0-units-ssm>
+ <test1--instantiationEssenceTrack-essenceTrackFrameRate-ssm type="array">
+   <test1--instantiationEssenceTrack-essenceTrackFrameRate-ssm>frame_rate</test1--instantiationEssenceTrack-essenceTrackFrameRate-ssm>
+ </test1--instantiationEssenceTrack-essenceTrackFrameRate-ssm>
+ <test1--instantiationEssenceTrack-0-essenceTrackFrameRate-ssm type="array">
+   <test1--instantiationEssenceTrack-0-essenceTrackFrameRate-ssm>frame_rate</test1--instantiationEssenceTrack-0-essenceTrackFrameRate-ssm>
+ </test1--instantiationEssenceTrack-0-essenceTrackFrameRate-ssm>
+ <test1--instantiationEssenceTrack-essenceTrackFrameSize-ssm type="array">
+   <test1--instantiationEssenceTrack-essenceTrackFrameSize-ssm>frame_size</test1--instantiationEssenceTrack-essenceTrackFrameSize-ssm>
+ </test1--instantiationEssenceTrack-essenceTrackFrameSize-ssm>
+ <test1--instantiationEssenceTrack-0-essenceTrackFrameSize-ssm type="array">
+   <test1--instantiationEssenceTrack-0-essenceTrackFrameSize-ssm>frame_size</test1--instantiationEssenceTrack-0-essenceTrackFrameSize-ssm>
+ </test1--instantiationEssenceTrack-0-essenceTrackFrameSize-ssm>
+ <test1--instantiationEssenceTrack-essenceTrackBitDepth-ssm type="array">
+   <test1--instantiationEssenceTrack-essenceTrackBitDepth-ssm>video_bit_depth</test1--instantiationEssenceTrack-essenceTrackBitDepth-ssm>
+   <test1--instantiationEssenceTrack-essenceTrackBitDepth-ssm>audio_bit_depth</test1--instantiationEssenceTrack-essenceTrackBitDepth-ssm>
+ </test1--instantiationEssenceTrack-essenceTrackBitDepth-ssm>
+ <test1--instantiationEssenceTrack-0-essenceTrackBitDepth-ssm type="array">
+   <test1--instantiationEssenceTrack-0-essenceTrackBitDepth-ssm>video_bit_depth</test1--instantiationEssenceTrack-0-essenceTrackBitDepth-ssm>
+ </test1--instantiationEssenceTrack-0-essenceTrackBitDepth-ssm>
+ <test1--instantiationEssenceTrack-essenceTrackAspectRatio-ssm type="array">
+   <test1--instantiationEssenceTrack-essenceTrackAspectRatio-ssm>aspect_ratio</test1--instantiationEssenceTrack-essenceTrackAspectRatio-ssm>
+ </test1--instantiationEssenceTrack-essenceTrackAspectRatio-ssm>
+ <test1--instantiationEssenceTrack-0-essenceTrackAspectRatio-ssm type="array">
+   <test1--instantiationEssenceTrack-0-essenceTrackAspectRatio-ssm>aspect_ratio</test1--instantiationEssenceTrack-0-essenceTrackAspectRatio-ssm>
+ </test1--instantiationEssenceTrack-0-essenceTrackAspectRatio-ssm>
+ <test1--instantiationEssenceTrack-1-essenceTrackStandard-ssm type="array">
+   <test1--instantiationEssenceTrack-1-essenceTrackStandard-ssm>audio_standard</test1--instantiationEssenceTrack-1-essenceTrackStandard-ssm>
+ </test1--instantiationEssenceTrack-1-essenceTrackStandard-ssm>
+ <test1--instantiationEssenceTrack-1-essenceTrackEncoding-ssm type="array">
+   <test1--instantiationEssenceTrack-1-essenceTrackEncoding-ssm>audio_encoding</test1--instantiationEssenceTrack-1-essenceTrackEncoding-ssm>
+ </test1--instantiationEssenceTrack-1-essenceTrackEncoding-ssm>
+ <test1--instantiationEssenceTrack-1-essenceTrackDataRate-ssm type="array">
+   <test1--instantiationEssenceTrack-1-essenceTrackDataRate-ssm>audio_bit_rate</test1--instantiationEssenceTrack-1-essenceTrackDataRate-ssm>
+ </test1--instantiationEssenceTrack-1-essenceTrackDataRate-ssm>
+ <test1--instantiationEssenceTrack-1-essenceTrackDataRate-0-units-ssm type="array">
+   <test1--instantiationEssenceTrack-1-essenceTrackDataRate-0-units-ssm>audio_bit_rate_units</test1--instantiationEssenceTrack-1-essenceTrackDataRate-0-units-ssm>
+ </test1--instantiationEssenceTrack-1-essenceTrackDataRate-0-units-ssm>
+ <test1--instantiationEssenceTrack-1-essenceTrackBitDepth-ssm type="array">
+   <test1--instantiationEssenceTrack-1-essenceTrackBitDepth-ssm>audio_bit_depth</test1--instantiationEssenceTrack-1-essenceTrackBitDepth-ssm>
+ </test1--instantiationEssenceTrack-1-essenceTrackBitDepth-ssm>
+ <test1--instantiationEssenceTrack-essenceTrackSamplingRate-ssm type="array">
+   <test1--instantiationEssenceTrack-essenceTrackSamplingRate-ssm>audio_sample_rate</test1--instantiationEssenceTrack-essenceTrackSamplingRate-ssm>
+ </test1--instantiationEssenceTrack-essenceTrackSamplingRate-ssm>
+ <test1--instantiationEssenceTrack-1-essenceTrackSamplingRate-ssm type="array">
+   <test1--instantiationEssenceTrack-1-essenceTrackSamplingRate-ssm>audio_sample_rate</test1--instantiationEssenceTrack-1-essenceTrackSamplingRate-ssm>
+ </test1--instantiationEssenceTrack-1-essenceTrackSamplingRate-ssm>
+ <test1--instantiationEssenceTrack-essenceTrackSamplingRate-units-ssm type="array">
+   <test1--instantiationEssenceTrack-essenceTrackSamplingRate-units-ssm>audio_sample_rate_units</test1--instantiationEssenceTrack-essenceTrackSamplingRate-units-ssm>
+ </test1--instantiationEssenceTrack-essenceTrackSamplingRate-units-ssm>
+ <test1--instantiationEssenceTrack-1-essenceTrackSamplingRate-0-units-ssm type="array">
+   <test1--instantiationEssenceTrack-1-essenceTrackSamplingRate-0-units-ssm>audio_sample_rate_units</test1--instantiationEssenceTrack-1-essenceTrackSamplingRate-0-units-ssm>
+ </test1--instantiationEssenceTrack-1-essenceTrackSamplingRate-0-units-ssm>
+ <test1--instantiationEssenceTrack-essenceTrackAnnotation-ssm type="array">
+   <test1--instantiationEssenceTrack-essenceTrackAnnotation-ssm>audio_channels</test1--instantiationEssenceTrack-essenceTrackAnnotation-ssm>
+ </test1--instantiationEssenceTrack-essenceTrackAnnotation-ssm>
+ <test1--instantiationEssenceTrack-1-essenceTrackAnnotation-ssm type="array">
+   <test1--instantiationEssenceTrack-1-essenceTrackAnnotation-ssm>audio_channels</test1--instantiationEssenceTrack-1-essenceTrackAnnotation-ssm>
+ </test1--instantiationEssenceTrack-1-essenceTrackAnnotation-ssm>
+ <test1--video-essence-essenceTrackStandard-ssm type="array">
+   <test1--video-essence-essenceTrackStandard-ssm>video_standard</test1--video-essence-essenceTrackStandard-ssm>
+ </test1--video-essence-essenceTrackStandard-ssm>
+ <test1--video-essence-0-essenceTrackStandard-ssm type="array">
+   <test1--video-essence-0-essenceTrackStandard-ssm>video_standard</test1--video-essence-0-essenceTrackStandard-ssm>
+ </test1--video-essence-0-essenceTrackStandard-ssm>
+ <test1--video-essence-essenceTrackEncoding-ssm type="array">
+   <test1--video-essence-essenceTrackEncoding-ssm>video_encoding</test1--video-essence-essenceTrackEncoding-ssm>
+ </test1--video-essence-essenceTrackEncoding-ssm>
+ <test1--video-essence-0-essenceTrackEncoding-ssm type="array">
+   <test1--video-essence-0-essenceTrackEncoding-ssm>video_encoding</test1--video-essence-0-essenceTrackEncoding-ssm>
+ </test1--video-essence-0-essenceTrackEncoding-ssm>
+ <test1--video-essence-essenceTrackDataRate-ssm type="array">
+   <test1--video-essence-essenceTrackDataRate-ssm>video_bit_rate</test1--video-essence-essenceTrackDataRate-ssm>
+ </test1--video-essence-essenceTrackDataRate-ssm>
+ <test1--video-essence-0-essenceTrackDataRate-ssm type="array">
+   <test1--video-essence-0-essenceTrackDataRate-ssm>video_bit_rate</test1--video-essence-0-essenceTrackDataRate-ssm>
+ </test1--video-essence-0-essenceTrackDataRate-ssm>
+ <test1--video-essence-essenceTrackDataRate-units-ssm type="array">
+   <test1--video-essence-essenceTrackDataRate-units-ssm>video_bit_rate_units</test1--video-essence-essenceTrackDataRate-units-ssm>
+ </test1--video-essence-essenceTrackDataRate-units-ssm>
+ <test1--video-essence-0-essenceTrackDataRate-0-units-ssm type="array">
+   <test1--video-essence-0-essenceTrackDataRate-0-units-ssm>video_bit_rate_units</test1--video-essence-0-essenceTrackDataRate-0-units-ssm>
+ </test1--video-essence-0-essenceTrackDataRate-0-units-ssm>
+ <test1--video-essence-essenceTrackFrameRate-ssm type="array">
+   <test1--video-essence-essenceTrackFrameRate-ssm>frame_rate</test1--video-essence-essenceTrackFrameRate-ssm>
+ </test1--video-essence-essenceTrackFrameRate-ssm>
+ <test1--video-essence-0-essenceTrackFrameRate-ssm type="array">
+   <test1--video-essence-0-essenceTrackFrameRate-ssm>frame_rate</test1--video-essence-0-essenceTrackFrameRate-ssm>
+ </test1--video-essence-0-essenceTrackFrameRate-ssm>
+ <test1--video-essence-essenceTrackFrameSize-ssm type="array">
+   <test1--video-essence-essenceTrackFrameSize-ssm>frame_size</test1--video-essence-essenceTrackFrameSize-ssm>
+ </test1--video-essence-essenceTrackFrameSize-ssm>
+ <test1--video-essence-0-essenceTrackFrameSize-ssm type="array">
+   <test1--video-essence-0-essenceTrackFrameSize-ssm>frame_size</test1--video-essence-0-essenceTrackFrameSize-ssm>
+ </test1--video-essence-0-essenceTrackFrameSize-ssm>
+ <test1--video-essence-essenceTrackBitDepth-ssm type="array">
+   <test1--video-essence-essenceTrackBitDepth-ssm>video_bit_depth</test1--video-essence-essenceTrackBitDepth-ssm>
+ </test1--video-essence-essenceTrackBitDepth-ssm>
+ <test1--video-essence-0-essenceTrackBitDepth-ssm type="array">
+   <test1--video-essence-0-essenceTrackBitDepth-ssm>video_bit_depth</test1--video-essence-0-essenceTrackBitDepth-ssm>
+ </test1--video-essence-0-essenceTrackBitDepth-ssm>
+ <test1--video-essence-essenceTrackAspectRatio-ssm type="array">
+   <test1--video-essence-essenceTrackAspectRatio-ssm>aspect_ratio</test1--video-essence-essenceTrackAspectRatio-ssm>
+ </test1--video-essence-essenceTrackAspectRatio-ssm>
+ <test1--video-essence-0-essenceTrackAspectRatio-ssm type="array">
+   <test1--video-essence-0-essenceTrackAspectRatio-ssm>aspect_ratio</test1--video-essence-0-essenceTrackAspectRatio-ssm>
+ </test1--video-essence-0-essenceTrackAspectRatio-ssm>
+ <test1--audio-essence-essenceTrackStandard-ssm type="array">
+   <test1--audio-essence-essenceTrackStandard-ssm>audio_standard</test1--audio-essence-essenceTrackStandard-ssm>
+ </test1--audio-essence-essenceTrackStandard-ssm>
+ <test1--audio-essence-0-essenceTrackStandard-ssm type="array">
+   <test1--audio-essence-0-essenceTrackStandard-ssm>audio_standard</test1--audio-essence-0-essenceTrackStandard-ssm>
+ </test1--audio-essence-0-essenceTrackStandard-ssm>
+ <test1--audio-essence-essenceTrackEncoding-ssm type="array">
+   <test1--audio-essence-essenceTrackEncoding-ssm>audio_encoding</test1--audio-essence-essenceTrackEncoding-ssm>
+ </test1--audio-essence-essenceTrackEncoding-ssm>
+ <test1--audio-essence-0-essenceTrackEncoding-ssm type="array">
+   <test1--audio-essence-0-essenceTrackEncoding-ssm>audio_encoding</test1--audio-essence-0-essenceTrackEncoding-ssm>
+ </test1--audio-essence-0-essenceTrackEncoding-ssm>
+ <test1--audio-essence-essenceTrackDataRate-ssm type="array">
+   <test1--audio-essence-essenceTrackDataRate-ssm>audio_bit_rate</test1--audio-essence-essenceTrackDataRate-ssm>
+ </test1--audio-essence-essenceTrackDataRate-ssm>
+ <test1--audio-essence-0-essenceTrackDataRate-ssm type="array">
+   <test1--audio-essence-0-essenceTrackDataRate-ssm>audio_bit_rate</test1--audio-essence-0-essenceTrackDataRate-ssm>
+ </test1--audio-essence-0-essenceTrackDataRate-ssm>
+ <test1--audio-essence-essenceTrackDataRate-units-ssm type="array">
+   <test1--audio-essence-essenceTrackDataRate-units-ssm>audio_bit_rate_units</test1--audio-essence-essenceTrackDataRate-units-ssm>
+ </test1--audio-essence-essenceTrackDataRate-units-ssm>
+ <test1--audio-essence-0-essenceTrackDataRate-0-units-ssm type="array">
+   <test1--audio-essence-0-essenceTrackDataRate-0-units-ssm>audio_bit_rate_units</test1--audio-essence-0-essenceTrackDataRate-0-units-ssm>
+ </test1--audio-essence-0-essenceTrackDataRate-0-units-ssm>
+ <test1--audio-essence-essenceTrackBitDepth-ssm type="array">
+   <test1--audio-essence-essenceTrackBitDepth-ssm>audio_bit_depth</test1--audio-essence-essenceTrackBitDepth-ssm>
+ </test1--audio-essence-essenceTrackBitDepth-ssm>
+ <test1--audio-essence-0-essenceTrackBitDepth-ssm type="array">
+   <test1--audio-essence-0-essenceTrackBitDepth-ssm>audio_bit_depth</test1--audio-essence-0-essenceTrackBitDepth-ssm>
+ </test1--audio-essence-0-essenceTrackBitDepth-ssm>
+ <test1--audio-essence-essenceTrackSamplingRate-ssm type="array">
+   <test1--audio-essence-essenceTrackSamplingRate-ssm>audio_sample_rate</test1--audio-essence-essenceTrackSamplingRate-ssm>
+ </test1--audio-essence-essenceTrackSamplingRate-ssm>
+ <test1--audio-essence-0-essenceTrackSamplingRate-ssm type="array">
+   <test1--audio-essence-0-essenceTrackSamplingRate-ssm>audio_sample_rate</test1--audio-essence-0-essenceTrackSamplingRate-ssm>
+ </test1--audio-essence-0-essenceTrackSamplingRate-ssm>
+ <test1--audio-essence-essenceTrackSamplingRate-units-ssm type="array">
+   <test1--audio-essence-essenceTrackSamplingRate-units-ssm>audio_sample_rate_units</test1--audio-essence-essenceTrackSamplingRate-units-ssm>
+ </test1--audio-essence-essenceTrackSamplingRate-units-ssm>
+ <test1--audio-essence-0-essenceTrackSamplingRate-0-units-ssm type="array">
+   <test1--audio-essence-0-essenceTrackSamplingRate-0-units-ssm>audio_sample_rate_units</test1--audio-essence-0-essenceTrackSamplingRate-0-units-ssm>
+ </test1--audio-essence-0-essenceTrackSamplingRate-0-units-ssm>
+ <test1--audio-essence-essenceTrackAnnotation-ssm type="array">
+   <test1--audio-essence-essenceTrackAnnotation-ssm>audio_channels</test1--audio-essence-essenceTrackAnnotation-ssm>
+ </test1--audio-essence-essenceTrackAnnotation-ssm>
+ <test1--audio-essence-0-essenceTrackAnnotation-ssm type="array">
+   <test1--audio-essence-0-essenceTrackAnnotation-ssm>audio_channels</test1--audio-essence-0-essenceTrackAnnotation-ssm>
+ </test1--audio-essence-0-essenceTrackAnnotation-ssm>
+ <test1--inst-chksum-type-ssm type="array">
+   <test1--inst-chksum-type-ssm>checksum_type</test1--inst-chksum-type-ssm>
+ </test1--inst-chksum-type-ssm>
+ <test1--inst-chksum-value-ssm type="array">
+   <test1--inst-chksum-value-ssm>checksum_value</test1--inst-chksum-value-ssm>
+ </test1--inst-chksum-value-ssm>
+ <test1--inst-device-ssm type="array">
+   <test1--inst-device-ssm>device</test1--inst-device-ssm>
+ </test1--inst-device-ssm>
+ <test1--inst-capture-soft-ssm type="array">
+   <test1--inst-capture-soft-ssm>capture_soft</test1--inst-capture-soft-ssm>
+ </test1--inst-capture-soft-ssm>
+ <test1--inst-trans-soft-ssm type="array">
+   <test1--inst-trans-soft-ssm>trans_soft</test1--inst-trans-soft-ssm>
+ </test1--inst-trans-soft-ssm>
+ <test1--inst-operator-ssm type="array">
+   <test1--inst-operator-ssm>operator</test1--inst-operator-ssm>
+ </test1--inst-operator-ssm>
+ <test1--inst-trans-note-ssm type="array">
+   <test1--inst-trans-note-ssm>trans_note</test1--inst-trans-note-ssm>
+ </test1--inst-trans-note-ssm>
+ <test1--inst-vendor-ssm type="array">
+   <test1--inst-vendor-ssm>vendor</test1--inst-vendor-ssm>
+ </test1--inst-vendor-ssm>
+ <test1--inst-cond-note-ssm type="array">
+   <test1--inst-cond-note-ssm>condition</test1--inst-cond-note-ssm>
+ </test1--inst-cond-note-ssm>
+ <test1--inst-clean-note-ssm type="array">
+   <test1--inst-clean-note-ssm>cleaning</test1--inst-clean-note-ssm>
+ </test1--inst-clean-note-ssm>
+ <test1--inst-note-ssm type="array">
+   <test1--inst-note-ssm>note</test1--inst-note-ssm>
+ </test1--inst-note-ssm>
+ <test1--inst-color-space-ssm type="array">
+   <test1--inst-color-space-ssm>color_space</test1--inst-color-space-ssm>
+ </test1--inst-color-space-ssm>
+ <test1--inst-chroma-ssm type="array">
+   <test1--inst-chroma-ssm>chroma</test1--inst-chroma-ssm>
+ </test1--inst-chroma-ssm>
+ <test1--condition-note-teim type="array">
+   <test1--condition-note-teim>condition</test1--condition-note-teim>
+ </test1--condition-note-teim>
+ <test1--condition-note-ssm type="array">
+   <test1--condition-note-ssm>condition</test1--condition-note-ssm>
+ </test1--condition-note-ssm>
+ <test1--cleaning-note-teim type="array">
+   <test1--cleaning-note-teim>cleaning</test1--cleaning-note-teim>
+ </test1--cleaning-note-teim>
+ <test1--cleaning-note-ssm type="array">
+   <test1--cleaning-note-ssm>cleaning</test1--cleaning-note-ssm>
+ </test1--cleaning-note-ssm>
+ <test1--location-ssm type="array">
+   <test1--location-ssm>location</test1--location-ssm>
+ </test1--location-ssm>
+ <test1--date-dtsim type="array">
+   <test1--date-dtsim>2012-11-01T00:00:00Z</test1--date-dtsim>
+ </test1--date-dtsim>
+ <test1--date-ssm type="array">
+   <test1--date-ssm>2012-11-01</test1--date-ssm>
+ </test1--date-ssm>
+ <test1--generation-ssm type="array">
+   <test1--generation-ssm>generation</test1--generation-ssm>
+ </test1--generation-ssm>
+ <test1--media-type-ssm type="array">
+   <test1--media-type-ssm>media_type</test1--media-type-ssm>
+ </test1--media-type-ssm>
+ <test1--media-type-sim type="array">
+   <test1--media-type-sim>media_type</test1--media-type-sim>
+ </test1--media-type-sim>
+ <test1--file-format-teim type="array">
+   <test1--file-format-teim>file_format</test1--file-format-teim>
+ </test1--file-format-teim>
+ <test1--file-format-ssm type="array">
+   <test1--file-format-ssm>file_format</test1--file-format-ssm>
+ </test1--file-format-ssm>
+ <test1--file-format-sim type="array">
+   <test1--file-format-sim>file_format</test1--file-format-sim>
+ </test1--file-format-sim>
+ <test1--size-ssm type="array">
+   <test1--size-ssm>size</test1--size-ssm>
+ </test1--size-ssm>
+ <test1--size-units-ssm type="array">
+   <test1--size-units-ssm>size_units</test1--size-units-ssm>
+ </test1--size-units-ssm>
+ <test1--colors-ssm type="array">
+   <test1--colors-ssm>colors</test1--colors-ssm>
+ </test1--colors-ssm>
+ <test1--duration-ssm type="array">
+   <test1--duration-ssm>duration</test1--duration-ssm>
+ </test1--duration-ssm>
+ <test1--rights-summary-ssm type="array">
+   <test1--rights-summary-ssm>rights_summary</test1--rights-summary-ssm>
+ </test1--rights-summary-ssm>
+ <test1--note-ssm type="array">
+   <test1--note-ssm>note</test1--note-ssm>
+ </test1--note-ssm>
+ <test1--checksum-type-ssm type="array">
+   <test1--checksum-type-ssm>checksum_type</test1--checksum-type-ssm>
+ </test1--checksum-type-ssm>
+ <test1--checksum-value-ssm type="array">
+   <test1--checksum-value-ssm>checksum_value</test1--checksum-value-ssm>
+ </test1--checksum-value-ssm>
+ <test1--device-ssm type="array">
+   <test1--device-ssm>device</test1--device-ssm>
+ </test1--device-ssm>
+ <test1--capture-soft-ssm type="array">
+   <test1--capture-soft-ssm>capture_soft</test1--capture-soft-ssm>
+ </test1--capture-soft-ssm>
+ <test1--trans-soft-ssm type="array">
+   <test1--trans-soft-ssm>trans_soft</test1--trans-soft-ssm>
+ </test1--trans-soft-ssm>
+ <test1--operator-ssm type="array">
+   <test1--operator-ssm>operator</test1--operator-ssm>
+ </test1--operator-ssm>
+ <test1--trans-note-ssm type="array">
+   <test1--trans-note-ssm>trans_note</test1--trans-note-ssm>
+ </test1--trans-note-ssm>
+ <test1--vendor-ssm type="array">
+   <test1--vendor-ssm>vendor</test1--vendor-ssm>
+ </test1--vendor-ssm>
+ <test1--condition-ssm type="array">
+   <test1--condition-ssm>condition</test1--condition-ssm>
+ </test1--condition-ssm>
+ <test1--cleaning-ssm type="array">
+   <test1--cleaning-ssm>cleaning</test1--cleaning-ssm>
+ </test1--cleaning-ssm>
+ <test1--color-space-ssm type="array">
+   <test1--color-space-ssm>color_space</test1--color-space-ssm>
+ </test1--color-space-ssm>
+ <test1--chroma-ssm type="array">
+   <test1--chroma-ssm>chroma</test1--chroma-ssm>
+ </test1--chroma-ssm>
+ <test1--video-standard-ssm type="array">
+   <test1--video-standard-ssm>video_standard</test1--video-standard-ssm>
+ </test1--video-standard-ssm>
+ <test1--video-encoding-ssm type="array">
+   <test1--video-encoding-ssm>video_encoding</test1--video-encoding-ssm>
+ </test1--video-encoding-ssm>
+ <test1--video-bit-rate-ssm type="array">
+   <test1--video-bit-rate-ssm>video_bit_rate</test1--video-bit-rate-ssm>
+ </test1--video-bit-rate-ssm>
+ <test1--video-bit-rate-units-ssm type="array">
+   <test1--video-bit-rate-units-ssm>video_bit_rate_units</test1--video-bit-rate-units-ssm>
+ </test1--video-bit-rate-units-ssm>
+ <test1--frame-rate-ssm type="array">
+   <test1--frame-rate-ssm>frame_rate</test1--frame-rate-ssm>
+ </test1--frame-rate-ssm>
+ <test1--frame-size-ssm type="array">
+   <test1--frame-size-ssm>frame_size</test1--frame-size-ssm>
+ </test1--frame-size-ssm>
+ <test1--video-bit-depth-ssm type="array">
+   <test1--video-bit-depth-ssm>video_bit_depth</test1--video-bit-depth-ssm>
+ </test1--video-bit-depth-ssm>
+ <test1--aspect-ratio-ssm type="array">
+   <test1--aspect-ratio-ssm>aspect_ratio</test1--aspect-ratio-ssm>
+ </test1--aspect-ratio-ssm>
+ <test1--audio-standard-ssm type="array">
+   <test1--audio-standard-ssm>audio_standard</test1--audio-standard-ssm>
+ </test1--audio-standard-ssm>
+ <test1--audio-encoding-ssm type="array">
+   <test1--audio-encoding-ssm>audio_encoding</test1--audio-encoding-ssm>
+ </test1--audio-encoding-ssm>
+ <test1--audio-bit-rate-ssm type="array">
+   <test1--audio-bit-rate-ssm>audio_bit_rate</test1--audio-bit-rate-ssm>
+ </test1--audio-bit-rate-ssm>
+ <test1--audio-bit-rate-units-ssm type="array">
+   <test1--audio-bit-rate-units-ssm>audio_bit_rate_units</test1--audio-bit-rate-units-ssm>
+ </test1--audio-bit-rate-units-ssm>
+ <test1--audio-sample-rate-ssm type="array">
+   <test1--audio-sample-rate-ssm>audio_sample_rate</test1--audio-sample-rate-ssm>
+ </test1--audio-sample-rate-ssm>
+ <test1--audio-sample-rate-units-ssm type="array">
+   <test1--audio-sample-rate-units-ssm>audio_sample_rate_units</test1--audio-sample-rate-units-ssm>
+ </test1--audio-sample-rate-units-ssm>
+ <test1--audio-bit-depth-ssm type="array">
+   <test1--audio-bit-depth-ssm>audio_bit_depth</test1--audio-bit-depth-ssm>
+ </test1--audio-bit-depth-ssm>
+ <test1--audio-channels-ssm type="array">
+   <test1--audio-channels-ssm>audio_channels</test1--audio-channels-ssm>
+ </test1--audio-channels-ssm>
 </hash>

--- a/spec/fixtures/document.xml
+++ b/spec/fixtures/document.xml
@@ -1,81 +1,83 @@
+<?xml version="1.0"?>
 <pbcoreDescriptionDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.pbcore.org/PBCore/PBCoreNamespace.html">
-  <pbcoreIdentifier source="Rock and Roll Hall of Fame and Museum" annotation="PID">inserted</pbcoreIdentifier>
-  <pbcoreTitle titleType="Main">inserted</pbcoreTitle>
-  <pbcoreDescription descriptionType="Description" descriptionTypeSource="pbcoreDescription/descriptionType" descriptionTypeRef="http://pbcore.org/vocabularies/pbcoreDescription/descriptionType#description" annotation="Summary">inserted</pbcoreDescription>
-  <pbcoreDescription descriptionType="Table of Contents" descriptionTypeSource="pbcoreDescription/descriptionType" descriptionTypeRef="http://pbcore.org/vocabularies/pbcoreDescription/descriptionType#table-of-contents" annotation="Parts List">inserted</pbcoreDescription>
-  <pbcoreRightsSummary>
-    <rightsSummary>inserted</rightsSummary>
-  </pbcoreRightsSummary>
-  <pbcoreAnnotation annotationType="Notes">inserted</pbcoreAnnotation>
-  <pbcorePublisher>
-    <publisher>inserted</publisher>
-    <publisherRole source="PBCore publisherRole">inserted</publisherRole>
-  </pbcorePublisher>
-  <pbcoreContributor>
-    <contributor>inserted</contributor>
-    <contributorRole source="MARC relator terms">inserted</contributorRole>
-  </pbcoreContributor>
-  <pbcorePublisher>
-    <publisher>inserted</publisher>
-    <publisherRole source="PBCore publisherRole"></publisherRole>
-  </pbcorePublisher>
-  <pbcoreContributor>
-    <contributor>inserted</contributor>
-    <contributorRole source="MARC relator terms"></contributorRole>
-  </pbcoreContributor>
-  <pbcoreContributor>
-    <contributor></contributor>
-    <contributorRole source="MARC relator terms"></contributorRole>
-  </pbcoreContributor>
-  <pbcoreCoverage>
-    <coverage annotation="Event Place">inserted</coverage>
-    <coverageType>Spatial</coverageType>
-  </pbcoreCoverage>
-  <pbcoreCoverage>
-    <coverage annotation="Event Date">2012-11-11</coverage>
-    <coverageType>Temporal</coverageType>
-  </pbcoreCoverage>
-  <pbcoreCoverage>
-    <coverage annotation="Event Date">2012-11-12</coverage>
-    <coverageType>Temporal</coverageType>
-  </pbcoreCoverage>
-  <pbcoreRelation>
-    <pbcoreRelationType source="PBCore relationType" ref="http://pbcore.org/vocabularies/relationType#is-part-of">Is Part Of</pbcoreRelationType>
-    <pbcoreRelationIdentifier annotation="Archival Collection">inserted</pbcoreRelationIdentifier>
-  </pbcoreRelation>
-  <pbcoreRelation>
-    <pbcoreRelationType source="PBCore relationType" ref="http://pbcore.org/vocabularies/relationType#is-part-of">Is Part Of</pbcoreRelationType>
-    <pbcoreRelationIdentifier annotation="Event Series">inserted</pbcoreRelationIdentifier>
-  </pbcoreRelation>
-  <pbcoreRelation>
-    <pbcoreRelationType source="PBCore relationType" ref="http://pbcore.org/vocabularies/relationType#is-part-of">Is Part Of</pbcoreRelationType>
-    <pbcoreRelationIdentifier annotation="Archival Series">inserted</pbcoreRelationIdentifier>
-  </pbcoreRelation>
-  <pbcoreRelation>
-    <pbcoreRelationType source="PBCore relationType" ref="http://pbcore.org/vocabularies/relationType#is-part-of">Is Part Of</pbcoreRelationType>
-    <pbcoreRelationIdentifier annotation="Accession Number">inserted</pbcoreRelationIdentifier>
-  </pbcoreRelation>
-  <pbcoreRelation>
-    <pbcoreRelationType source="PBCore relationType" ref="http://pbcore.org/vocabularies/relationType#is-part-of">Is Part Of</pbcoreRelationType>
-    <pbcoreRelationIdentifier annotation="Collection Number">inserted</pbcoreRelationIdentifier>
-  </pbcoreRelation>
-  <pbcoreRelation>
-    <pbcoreRelationType source="PBCore relationType" ref="http://pbcore.org/vocabularies/relationType#is-part-of">Is Part Of</pbcoreRelationType>
-    <pbcoreRelationIdentifier annotation="Additional Collection">inserted</pbcoreRelationIdentifier>
-  </pbcoreRelation>
-  <pbcoreTitle titleType="Alternative">inserted</pbcoreTitle>
-  <pbcoreTitle titleType="Chapter">inserted</pbcoreTitle>
-  <pbcoreTitle titleType="Episode">inserted</pbcoreTitle>
-  <pbcoreTitle titleType="Label">inserted</pbcoreTitle>
-  <pbcoreTitle titleType="Segment">inserted</pbcoreTitle>
-  <pbcoreTitle titleType="Subtitle">inserted</pbcoreTitle>
-  <pbcoreTitle titleType="Track">inserted</pbcoreTitle>
-  <pbcoreTitle titleType="Translation">inserted</pbcoreTitle>
-  <pbcoreSubject source="Library of Congress Subject Headings" ref="http://id.loc.gov/authorities/subjects.html">inserted</pbcoreSubject>
-  <pbcoreSubject source="Library of Congress Name Authority File" ref="http://id.loc.gov/authorities/names">inserted</pbcoreSubject>
-  <pbcoreSubject source="Rock and Roll Hall of Fame and Museum">inserted</pbcoreSubject>
-  <pbcoreGenre source="The Getty Research Institute Art and Architecture Thesaurus" ref="http://www.getty.edu/research/tools/vocabularies/aat/index.html">inserted</pbcoreGenre>
-  <pbcoreGenre source="Library of Congress Genre/Form Terms" ref="http://id.loc.gov/authorities/genreForms.html">inserted</pbcoreGenre>
-  <pbcoreGenre source="Library of Congress Subject Headings" ref="http://id.loc.gov/authorities/subjects.html">inserted</pbcoreGenre>
-  <pbcoreAssetType>Scene</pbcoreAssetType>
+ <pbcoreTitle titleType="Main">inserted</pbcoreTitle>
+ <pbcoreDescription descriptionType="Description" descriptionTypeSource="pbcoreDescription/descriptionType" descriptionTypeRef="http://pbcore.org/vocabularies/pbcoreDescription/descriptionType#description" annotation="Summary">inserted</pbcoreDescription>
+ <pbcoreDescription descriptionType="Table of Contents" descriptionTypeSource="pbcoreDescription/descriptionType" descriptionTypeRef="http://pbcore.org/vocabularies/pbcoreDescription/descriptionType#table-of-contents" annotation="Parts List">inserted</pbcoreDescription>
+ <pbcoreRightsSummary>
+   <rightsSummary>inserted</rightsSummary>
+ </pbcoreRightsSummary>
+ <pbcoreAnnotation annotationType="Notes">inserted</pbcoreAnnotation>
+ <pbcoreIdentifier source="Rock and Roll Hall of Fame and Museum">test-datastream</pbcoreIdentifier>
+ <pbcoreIdentifier source="Rock and Roll Hall of Fame and Museum" annotation="PID">inserted</pbcoreIdentifier>
+ <pbcorePublisher>
+   <publisher>inserted</publisher>
+   <publisherRole source="PBCore publisherRole">inserted</publisherRole>
+ </pbcorePublisher>
+ <pbcoreContributor>
+   <contributor>inserted</contributor>
+   <contributorRole source="MARC relator terms">inserted</contributorRole>
+ </pbcoreContributor>
+ <pbcorePublisher>
+   <publisher>inserted</publisher>
+   <publisherRole source="PBCore publisherRole"/>
+ </pbcorePublisher>
+ <pbcoreContributor>
+   <contributor>inserted</contributor>
+   <contributorRole source="MARC relator terms"/>
+ </pbcoreContributor>
+ <pbcoreContributor>
+   <contributor/>
+   <contributorRole source="MARC relator terms"/>
+ </pbcoreContributor>
+ <pbcoreCoverage>
+   <coverage annotation="Event Place">inserted</coverage>
+   <coverageType>Spatial</coverageType>
+ </pbcoreCoverage>
+ <pbcoreCoverage>
+   <coverage annotation="Event Date">2012-11-11</coverage>
+   <coverageType>Temporal</coverageType>
+ </pbcoreCoverage>
+ <pbcoreCoverage>
+   <coverage annotation="Event Date">2012-11-12</coverage>
+   <coverageType>Temporal</coverageType>
+ </pbcoreCoverage>
+ <pbcoreRelation>
+   <pbcoreRelationType source="PBCore relationType" ref="http://pbcore.org/vocabularies/relationType#is-part-of">Is Part Of</pbcoreRelationType>
+   <pbcoreRelationIdentifier annotation="Archival Collection">inserted</pbcoreRelationIdentifier>
+ </pbcoreRelation>
+ <pbcoreRelation>
+   <pbcoreRelationType source="PBCore relationType" ref="http://pbcore.org/vocabularies/relationType#is-part-of">Is Part Of</pbcoreRelationType>
+   <pbcoreRelationIdentifier annotation="Event Series">inserted</pbcoreRelationIdentifier>
+ </pbcoreRelation>
+ <pbcoreRelation>
+   <pbcoreRelationType source="PBCore relationType" ref="http://pbcore.org/vocabularies/relationType#is-part-of">Is Part Of</pbcoreRelationType>
+   <pbcoreRelationIdentifier annotation="Archival Series">inserted</pbcoreRelationIdentifier>
+ </pbcoreRelation>
+ <pbcoreRelation>
+   <pbcoreRelationType source="PBCore relationType" ref="http://pbcore.org/vocabularies/relationType#is-part-of">Is Part Of</pbcoreRelationType>
+   <pbcoreRelationIdentifier annotation="Accession Number">inserted</pbcoreRelationIdentifier>
+ </pbcoreRelation>
+ <pbcoreRelation>
+   <pbcoreRelationType source="PBCore relationType" ref="http://pbcore.org/vocabularies/relationType#is-part-of">Is Part Of</pbcoreRelationType>
+   <pbcoreRelationIdentifier annotation="Collection Number">inserted</pbcoreRelationIdentifier>
+ </pbcoreRelation>
+ <pbcoreRelation>
+   <pbcoreRelationType source="PBCore relationType" ref="http://pbcore.org/vocabularies/relationType#is-part-of">Is Part Of</pbcoreRelationType>
+   <pbcoreRelationIdentifier annotation="Additional Collection">inserted</pbcoreRelationIdentifier>
+ </pbcoreRelation>
+ <pbcoreTitle titleType="Alternative">inserted</pbcoreTitle>
+ <pbcoreTitle titleType="Chapter">inserted</pbcoreTitle>
+ <pbcoreTitle titleType="Episode">inserted</pbcoreTitle>
+ <pbcoreTitle titleType="Label">inserted</pbcoreTitle>
+ <pbcoreTitle titleType="Segment">inserted</pbcoreTitle>
+ <pbcoreTitle titleType="Subtitle">inserted</pbcoreTitle>
+ <pbcoreTitle titleType="Track">inserted</pbcoreTitle>
+ <pbcoreTitle titleType="Translation">inserted</pbcoreTitle>
+ <pbcoreSubject source="Library of Congress Subject Headings" ref="http://id.loc.gov/authorities/subjects.html">inserted</pbcoreSubject>
+ <pbcoreSubject source="Library of Congress Name Authority File" ref="http://id.loc.gov/authorities/names">inserted</pbcoreSubject>
+ <pbcoreSubject source="Rock and Roll Hall of Fame and Museum">inserted</pbcoreSubject>
+ <pbcoreGenre source="The Getty Research Institute Art and Architecture Thesaurus" ref="http://www.getty.edu/research/tools/vocabularies/aat/index.html">inserted</pbcoreGenre>
+ <pbcoreGenre source="Library of Congress Genre/Form Terms" ref="http://id.loc.gov/authorities/genreForms.html">inserted</pbcoreGenre>
+ <pbcoreGenre source="Library of Congress Subject Headings" ref="http://id.loc.gov/authorities/subjects.html">inserted</pbcoreGenre>
+ <pbcoreAssetType>Scene</pbcoreAssetType>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/document_solr.xml
+++ b/spec/fixtures/document_solr.xml
@@ -1,236 +1,236 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hash>
-  <title-teim type="array">
-    <title-teim>inserted</title-teim>
-  </title-teim>
-  <title-ssm type="array">
-    <title-ssm>inserted</title-ssm>
-  </title-ssm>
-  <title-si>inserted</title-si>
-  <alternative-title-teim type="array">
-    <alternative-title-teim>inserted</alternative-title-teim>
-  </alternative-title-teim>
-  <alternative-title-ssm type="array">
-    <alternative-title-ssm>inserted</alternative-title-ssm>
-  </alternative-title-ssm>
-  <chapter-teim type="array">
-    <chapter-teim>inserted</chapter-teim>
-  </chapter-teim>
-  <chapter-ssm type="array">
-    <chapter-ssm>inserted</chapter-ssm>
-  </chapter-ssm>
-  <episode-teim type="array">
-    <episode-teim>inserted</episode-teim>
-  </episode-teim>
-  <episode-ssm type="array">
-    <episode-ssm>inserted</episode-ssm>
-  </episode-ssm>
-  <label-teim type="array">
-    <label-teim>inserted</label-teim>
-  </label-teim>
-  <label-ssm type="array">
-    <label-ssm>inserted</label-ssm>
-  </label-ssm>
-  <segment-teim type="array">
-    <segment-teim>inserted</segment-teim>
-  </segment-teim>
-  <segment-ssm type="array">
-    <segment-ssm>inserted</segment-ssm>
-  </segment-ssm>
-  <subtitle-teim type="array">
-    <subtitle-teim>inserted</subtitle-teim>
-  </subtitle-teim>
-  <subtitle-ssm type="array">
-    <subtitle-ssm>inserted</subtitle-ssm>
-  </subtitle-ssm>
-  <track-teim type="array">
-    <track-teim>inserted</track-teim>
-  </track-teim>
-  <track-ssm type="array">
-    <track-ssm>inserted</track-ssm>
-  </track-ssm>
-  <translation-teim type="array">
-    <translation-teim>inserted</translation-teim>
-  </translation-teim>
-  <translation-ssm type="array">
-    <translation-ssm>inserted</translation-ssm>
-  </translation-ssm>
-  <subject-ssm type="array">
-    <subject-ssm>inserted</subject-ssm>
-    <subject-ssm>inserted</subject-ssm>
-    <subject-ssm>inserted</subject-ssm>
-  </subject-ssm>
-  <subject-sim type="array">
-    <subject-sim>inserted</subject-sim>
-    <subject-sim>inserted</subject-sim>
-    <subject-sim>inserted</subject-sim>
-  </subject-sim>
-  <lc-subject-ssm type="array">
-    <lc-subject-ssm>inserted</lc-subject-ssm>
-  </lc-subject-ssm>
-  <lc-name-ssm type="array">
-    <lc-name-ssm>inserted</lc-name-ssm>
-  </lc-name-ssm>
-  <rh-subject-ssm type="array">
-    <rh-subject-ssm>inserted</rh-subject-ssm>
-  </rh-subject-ssm>
-  <summary-teim type="array">
-    <summary-teim>inserted</summary-teim>
-  </summary-teim>
-  <summary-ssm type="array">
-    <summary-ssm>inserted</summary-ssm>
-  </summary-ssm>
-  <contents-teim type="array">
-    <contents-teim>inserted</contents-teim>
-  </contents-teim>
-  <contents-ssm type="array">
-    <contents-ssm>inserted</contents-ssm>
-  </contents-ssm>
-  <genre-ssm type="array">
-    <genre-ssm>inserted</genre-ssm>
-    <genre-ssm>inserted</genre-ssm>
-    <genre-ssm>inserted</genre-ssm>
-  </genre-ssm>
-  <genre-sim type="array">
-    <genre-sim>inserted</genre-sim>
-    <genre-sim>inserted</genre-sim>
-    <genre-sim>inserted</genre-sim>
-  </genre-sim>
-  <asset-type-teim type="array">
-    <asset-type-teim>Scene</asset-type-teim>
-  </asset-type-teim>
-  <asset-type-ssm type="array">
-    <asset-type-ssm>Scene</asset-type-ssm>
-  </asset-type-ssm>
-  <asset-type-sim type="array">
-    <asset-type-sim>Scene</asset-type-sim>
-  </asset-type-sim>
-  <getty-genre-ssm type="array">
-    <getty-genre-ssm>inserted</getty-genre-ssm>
-  </getty-genre-ssm>
-  <lc-genre-ssm type="array">
-    <lc-genre-ssm>inserted</lc-genre-ssm>
-  </lc-genre-ssm>
-  <lc-subject-genre-ssm type="array">
-    <lc-subject-genre-ssm>inserted</lc-subject-genre-ssm>
-  </lc-subject-genre-ssm>
-  <series-teim type="array">
-    <series-teim>inserted</series-teim>
-  </series-teim>
-  <series-ssm type="array">
-    <series-ssm>inserted</series-ssm>
-  </series-ssm>
-  <series-sim type="array">
-    <series-sim>inserted</series-sim>
-  </series-sim>
-  <collection-teim type="array">
-    <collection-teim>inserted</collection-teim>
-  </collection-teim>
-  <collection-ssm type="array">
-    <collection-ssm>inserted</collection-ssm>
-  </collection-ssm>
-  <collection-sim type="array">
-    <collection-sim>inserted</collection-sim>
-  </collection-sim>
-  <archival-series-teim type="array">
-    <archival-series-teim>inserted</archival-series-teim>
-  </archival-series-teim>
-  <archival-series-ssm type="array">
-    <archival-series-ssm>inserted</archival-series-ssm>
-  </archival-series-ssm>
-  <archival-series-sim type="array">
-    <archival-series-sim>inserted</archival-series-sim>
-  </archival-series-sim>
-  <additional-collection-teim type="array">
-    <additional-collection-teim>inserted</additional-collection-teim>
-  </additional-collection-teim>
-  <additional-collection-ssm type="array">
-    <additional-collection-ssm>inserted</additional-collection-ssm>
-  </additional-collection-ssm>
-  <additional-collection-sim type="array">
-    <additional-collection-sim>inserted</additional-collection-sim>
-  </additional-collection-sim>
-  <collection-number-teim type="array">
-    <collection-number-teim>inserted</collection-number-teim>
-  </collection-number-teim>
-  <collection-number-ssm type="array">
-    <collection-number-ssm>inserted</collection-number-ssm>
-  </collection-number-ssm>
-  <accession-number-teim type="array">
-    <accession-number-teim>inserted</accession-number-teim>
-  </accession-number-teim>
-  <accession-number-ssm type="array">
-    <accession-number-ssm>inserted</accession-number-ssm>
-  </accession-number-ssm>
-  <event-place-teim type="array">
-    <event-place-teim>inserted</event-place-teim>
-  </event-place-teim>
-  <event-place-ssm type="array">
-    <event-place-ssm>inserted</event-place-ssm>
-  </event-place-ssm>
-  <event-date-dtsim type="array">
-    <event-date-dtsim>2012-11-11T00:00:00Z</event-date-dtsim>
-    <event-date-dtsim>2012-11-12T00:00:00Z</event-date-dtsim>
-  </event-date-dtsim>
-  <event-date-ssm type="array">
-    <event-date-ssm>2012-11-11</event-date-ssm>
-    <event-date-ssm>2012-11-12</event-date-ssm>
-  </event-date-ssm>
-  <contributor-name-teim type="array">
-    <contributor-name-teim>inserted</contributor-name-teim>
-    <contributor-name-teim>inserted</contributor-name-teim>
-    <contributor-name-teim></contributor-name-teim>
-  </contributor-name-teim>
-  <contributor-name-ssm type="array">
-    <contributor-name-ssm>inserted</contributor-name-ssm>
-    <contributor-name-ssm>inserted</contributor-name-ssm>
-    <contributor-name-ssm></contributor-name-ssm>
-  </contributor-name-ssm>
-  <contributor-name-sim type="array">
-    <contributor-name-sim>inserted</contributor-name-sim>
-    <contributor-name-sim>inserted</contributor-name-sim>
-    <contributor-name-sim></contributor-name-sim>
-  </contributor-name-sim>
-  <contributor-role-teim type="array">
-    <contributor-role-teim>inserted</contributor-role-teim>
-    <contributor-role-teim></contributor-role-teim>
-    <contributor-role-teim></contributor-role-teim>
-  </contributor-role-teim>
-  <contributor-role-ssm type="array">
-    <contributor-role-ssm>inserted</contributor-role-ssm>
-    <contributor-role-ssm></contributor-role-ssm>
-    <contributor-role-ssm></contributor-role-ssm>
-  </contributor-role-ssm>
-  <publisher-name-teim type="array">
-    <publisher-name-teim>inserted</publisher-name-teim>
-    <publisher-name-teim>inserted</publisher-name-teim>
-  </publisher-name-teim>
-  <publisher-name-ssm type="array">
-    <publisher-name-ssm>inserted</publisher-name-ssm>
-    <publisher-name-ssm>inserted</publisher-name-ssm>
-  </publisher-name-ssm>
-  <publisher-name-sim type="array">
-    <publisher-name-sim>inserted</publisher-name-sim>
-    <publisher-name-sim>inserted</publisher-name-sim>
-  </publisher-name-sim>
-  <publisher-role-teim type="array">
-    <publisher-role-teim>inserted</publisher-role-teim>
-    <publisher-role-teim></publisher-role-teim>
-  </publisher-role-teim>
-  <publisher-role-ssm type="array">
-    <publisher-role-ssm>inserted</publisher-role-ssm>
-    <publisher-role-ssm></publisher-role-ssm>
-  </publisher-role-ssm>
-  <note-teim type="array">
-    <note-teim>inserted</note-teim>
-  </note-teim>
-  <note-ssm type="array">
-    <note-ssm>inserted</note-ssm>
-  </note-ssm>
-  <rights-summary-teim type="array">
-    <rights-summary-teim>inserted</rights-summary-teim>
-  </rights-summary-teim>
-  <rights-summary-ssm type="array">
-    <rights-summary-ssm>inserted</rights-summary-ssm>
-  </rights-summary-ssm>
+ <test1--title-teim type="array">
+   <test1--title-teim>inserted</test1--title-teim>
+ </test1--title-teim>
+ <test1--title-ssm type="array">
+   <test1--title-ssm>inserted</test1--title-ssm>
+ </test1--title-ssm>
+ <test1--title-si>inserted</test1--title-si>
+ <test1--alternative-title-teim type="array">
+   <test1--alternative-title-teim>inserted</test1--alternative-title-teim>
+ </test1--alternative-title-teim>
+ <test1--alternative-title-ssm type="array">
+   <test1--alternative-title-ssm>inserted</test1--alternative-title-ssm>
+ </test1--alternative-title-ssm>
+ <test1--chapter-teim type="array">
+   <test1--chapter-teim>inserted</test1--chapter-teim>
+ </test1--chapter-teim>
+ <test1--chapter-ssm type="array">
+   <test1--chapter-ssm>inserted</test1--chapter-ssm>
+ </test1--chapter-ssm>
+ <test1--episode-teim type="array">
+   <test1--episode-teim>inserted</test1--episode-teim>
+ </test1--episode-teim>
+ <test1--episode-ssm type="array">
+   <test1--episode-ssm>inserted</test1--episode-ssm>
+ </test1--episode-ssm>
+ <test1--label-teim type="array">
+   <test1--label-teim>inserted</test1--label-teim>
+ </test1--label-teim>
+ <test1--label-ssm type="array">
+   <test1--label-ssm>inserted</test1--label-ssm>
+ </test1--label-ssm>
+ <test1--segment-teim type="array">
+   <test1--segment-teim>inserted</test1--segment-teim>
+ </test1--segment-teim>
+ <test1--segment-ssm type="array">
+   <test1--segment-ssm>inserted</test1--segment-ssm>
+ </test1--segment-ssm>
+ <test1--subtitle-teim type="array">
+   <test1--subtitle-teim>inserted</test1--subtitle-teim>
+ </test1--subtitle-teim>
+ <test1--subtitle-ssm type="array">
+   <test1--subtitle-ssm>inserted</test1--subtitle-ssm>
+ </test1--subtitle-ssm>
+ <test1--track-teim type="array">
+   <test1--track-teim>inserted</test1--track-teim>
+ </test1--track-teim>
+ <test1--track-ssm type="array">
+   <test1--track-ssm>inserted</test1--track-ssm>
+ </test1--track-ssm>
+ <test1--translation-teim type="array">
+   <test1--translation-teim>inserted</test1--translation-teim>
+ </test1--translation-teim>
+ <test1--translation-ssm type="array">
+   <test1--translation-ssm>inserted</test1--translation-ssm>
+ </test1--translation-ssm>
+ <test1--subject-ssm type="array">
+   <test1--subject-ssm>inserted</test1--subject-ssm>
+   <test1--subject-ssm>inserted</test1--subject-ssm>
+   <test1--subject-ssm>inserted</test1--subject-ssm>
+ </test1--subject-ssm>
+ <test1--subject-sim type="array">
+   <test1--subject-sim>inserted</test1--subject-sim>
+   <test1--subject-sim>inserted</test1--subject-sim>
+   <test1--subject-sim>inserted</test1--subject-sim>
+ </test1--subject-sim>
+ <test1--lc-subject-ssm type="array">
+   <test1--lc-subject-ssm>inserted</test1--lc-subject-ssm>
+ </test1--lc-subject-ssm>
+ <test1--lc-name-ssm type="array">
+   <test1--lc-name-ssm>inserted</test1--lc-name-ssm>
+ </test1--lc-name-ssm>
+ <test1--rh-subject-ssm type="array">
+   <test1--rh-subject-ssm>inserted</test1--rh-subject-ssm>
+ </test1--rh-subject-ssm>
+ <test1--summary-teim type="array">
+   <test1--summary-teim>inserted</test1--summary-teim>
+ </test1--summary-teim>
+ <test1--summary-ssm type="array">
+   <test1--summary-ssm>inserted</test1--summary-ssm>
+ </test1--summary-ssm>
+ <test1--contents-teim type="array">
+   <test1--contents-teim>inserted</test1--contents-teim>
+ </test1--contents-teim>
+ <test1--contents-ssm type="array">
+   <test1--contents-ssm>inserted</test1--contents-ssm>
+ </test1--contents-ssm>
+ <test1--genre-ssm type="array">
+   <test1--genre-ssm>inserted</test1--genre-ssm>
+   <test1--genre-ssm>inserted</test1--genre-ssm>
+   <test1--genre-ssm>inserted</test1--genre-ssm>
+ </test1--genre-ssm>
+ <test1--genre-sim type="array">
+   <test1--genre-sim>inserted</test1--genre-sim>
+   <test1--genre-sim>inserted</test1--genre-sim>
+   <test1--genre-sim>inserted</test1--genre-sim>
+ </test1--genre-sim>
+ <test1--asset-type-teim type="array">
+   <test1--asset-type-teim>Scene</test1--asset-type-teim>
+ </test1--asset-type-teim>
+ <test1--asset-type-ssm type="array">
+   <test1--asset-type-ssm>Scene</test1--asset-type-ssm>
+ </test1--asset-type-ssm>
+ <test1--asset-type-sim type="array">
+   <test1--asset-type-sim>Scene</test1--asset-type-sim>
+ </test1--asset-type-sim>
+ <test1--getty-genre-ssm type="array">
+   <test1--getty-genre-ssm>inserted</test1--getty-genre-ssm>
+ </test1--getty-genre-ssm>
+ <test1--lc-genre-ssm type="array">
+   <test1--lc-genre-ssm>inserted</test1--lc-genre-ssm>
+ </test1--lc-genre-ssm>
+ <test1--lc-subject-genre-ssm type="array">
+   <test1--lc-subject-genre-ssm>inserted</test1--lc-subject-genre-ssm>
+ </test1--lc-subject-genre-ssm>
+ <test1--series-teim type="array">
+   <test1--series-teim>inserted</test1--series-teim>
+ </test1--series-teim>
+ <test1--series-ssm type="array">
+   <test1--series-ssm>inserted</test1--series-ssm>
+ </test1--series-ssm>
+ <test1--series-sim type="array">
+   <test1--series-sim>inserted</test1--series-sim>
+ </test1--series-sim>
+ <test1--collection-teim type="array">
+   <test1--collection-teim>inserted</test1--collection-teim>
+ </test1--collection-teim>
+ <test1--collection-ssm type="array">
+   <test1--collection-ssm>inserted</test1--collection-ssm>
+ </test1--collection-ssm>
+ <test1--collection-sim type="array">
+   <test1--collection-sim>inserted</test1--collection-sim>
+ </test1--collection-sim>
+ <test1--archival-series-teim type="array">
+   <test1--archival-series-teim>inserted</test1--archival-series-teim>
+ </test1--archival-series-teim>
+ <test1--archival-series-ssm type="array">
+   <test1--archival-series-ssm>inserted</test1--archival-series-ssm>
+ </test1--archival-series-ssm>
+ <test1--archival-series-sim type="array">
+   <test1--archival-series-sim>inserted</test1--archival-series-sim>
+ </test1--archival-series-sim>
+ <test1--additional-collection-teim type="array">
+   <test1--additional-collection-teim>inserted</test1--additional-collection-teim>
+ </test1--additional-collection-teim>
+ <test1--additional-collection-ssm type="array">
+   <test1--additional-collection-ssm>inserted</test1--additional-collection-ssm>
+ </test1--additional-collection-ssm>
+ <test1--additional-collection-sim type="array">
+   <test1--additional-collection-sim>inserted</test1--additional-collection-sim>
+ </test1--additional-collection-sim>
+ <test1--collection-number-teim type="array">
+   <test1--collection-number-teim>inserted</test1--collection-number-teim>
+ </test1--collection-number-teim>
+ <test1--collection-number-ssm type="array">
+   <test1--collection-number-ssm>inserted</test1--collection-number-ssm>
+ </test1--collection-number-ssm>
+ <test1--accession-number-teim type="array">
+   <test1--accession-number-teim>inserted</test1--accession-number-teim>
+ </test1--accession-number-teim>
+ <test1--accession-number-ssm type="array">
+   <test1--accession-number-ssm>inserted</test1--accession-number-ssm>
+ </test1--accession-number-ssm>
+ <test1--event-place-teim type="array">
+   <test1--event-place-teim>inserted</test1--event-place-teim>
+ </test1--event-place-teim>
+ <test1--event-place-ssm type="array">
+   <test1--event-place-ssm>inserted</test1--event-place-ssm>
+ </test1--event-place-ssm>
+ <test1--event-date-dtsim type="array">
+   <test1--event-date-dtsim>2012-11-11T00:00:00Z</test1--event-date-dtsim>
+   <test1--event-date-dtsim>2012-11-12T00:00:00Z</test1--event-date-dtsim>
+ </test1--event-date-dtsim>
+ <test1--event-date-ssm type="array">
+   <test1--event-date-ssm>2012-11-11</test1--event-date-ssm>
+   <test1--event-date-ssm>2012-11-12</test1--event-date-ssm>
+ </test1--event-date-ssm>
+ <test1--contributor-name-teim type="array">
+   <test1--contributor-name-teim>inserted</test1--contributor-name-teim>
+   <test1--contributor-name-teim>inserted</test1--contributor-name-teim>
+   <test1--contributor-name-teim/>
+ </test1--contributor-name-teim>
+ <test1--contributor-name-ssm type="array">
+   <test1--contributor-name-ssm>inserted</test1--contributor-name-ssm>
+   <test1--contributor-name-ssm>inserted</test1--contributor-name-ssm>
+   <test1--contributor-name-ssm/>
+ </test1--contributor-name-ssm>
+ <test1--contributor-name-sim type="array">
+   <test1--contributor-name-sim>inserted</test1--contributor-name-sim>
+   <test1--contributor-name-sim>inserted</test1--contributor-name-sim>
+   <test1--contributor-name-sim/>
+ </test1--contributor-name-sim>
+ <test1--contributor-role-teim type="array">
+   <test1--contributor-role-teim>inserted</test1--contributor-role-teim>
+   <test1--contributor-role-teim/>
+   <test1--contributor-role-teim/>
+ </test1--contributor-role-teim>
+ <test1--contributor-role-ssm type="array">
+   <test1--contributor-role-ssm>inserted</test1--contributor-role-ssm>
+   <test1--contributor-role-ssm/>
+   <test1--contributor-role-ssm/>
+ </test1--contributor-role-ssm>
+ <test1--publisher-name-teim type="array">
+   <test1--publisher-name-teim>inserted</test1--publisher-name-teim>
+   <test1--publisher-name-teim>inserted</test1--publisher-name-teim>
+ </test1--publisher-name-teim>
+ <test1--publisher-name-ssm type="array">
+   <test1--publisher-name-ssm>inserted</test1--publisher-name-ssm>
+   <test1--publisher-name-ssm>inserted</test1--publisher-name-ssm>
+ </test1--publisher-name-ssm>
+ <test1--publisher-name-sim type="array">
+   <test1--publisher-name-sim>inserted</test1--publisher-name-sim>
+   <test1--publisher-name-sim>inserted</test1--publisher-name-sim>
+ </test1--publisher-name-sim>
+ <test1--publisher-role-teim type="array">
+   <test1--publisher-role-teim>inserted</test1--publisher-role-teim>
+   <test1--publisher-role-teim/>
+ </test1--publisher-role-teim>
+ <test1--publisher-role-ssm type="array">
+   <test1--publisher-role-ssm>inserted</test1--publisher-role-ssm>
+   <test1--publisher-role-ssm/>
+ </test1--publisher-role-ssm>
+ <test1--note-teim type="array">
+   <test1--note-teim>inserted</test1--note-teim>
+ </test1--note-teim>
+ <test1--note-ssm type="array">
+   <test1--note-ssm>inserted</test1--note-ssm>
+ </test1--note-ssm>
+ <test1--rights-summary-teim type="array">
+   <test1--rights-summary-teim>inserted</test1--rights-summary-teim>
+ </test1--rights-summary-teim>
+ <test1--rights-summary-ssm type="array">
+   <test1--rights-summary-ssm>inserted</test1--rights-summary-ssm>
+ </test1--rights-summary-ssm>
 </hash>

--- a/spec/fixtures/document_template.xml
+++ b/spec/fixtures/document_template.xml
@@ -1,9 +1,11 @@
+<?xml version="1.0"?>
 <pbcoreDescriptionDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.pbcore.org/PBCore/PBCoreNamespace.html">
-  <pbcoreTitle titleType="Main"/>
-  <pbcoreDescription descriptionType="Description" descriptionTypeSource="pbcoreDescription/descriptionType" descriptionTypeRef="http://pbcore.org/vocabularies/pbcoreDescription/descriptionType#description" annotation="Summary"/>
-  <pbcoreDescription descriptionType="Table of Contents" descriptionTypeSource="pbcoreDescription/descriptionType" descriptionTypeRef="http://pbcore.org/vocabularies/pbcoreDescription/descriptionType#table-of-contents" annotation="Parts List"/>
-  <pbcoreRightsSummary>
-    <rightsSummary/>
-  </pbcoreRightsSummary>
-  <pbcoreAnnotation annotationType="Notes"/>
+	<pbcoreTitle titleType="Main"/>
+	<pbcoreDescription descriptionType="Description" descriptionTypeSource="pbcoreDescription/descriptionType" descriptionTypeRef="http://pbcore.org/vocabularies/pbcoreDescription/descriptionType#description" annotation="Summary"/>
+	<pbcoreDescription descriptionType="Table of Contents" descriptionTypeSource="pbcoreDescription/descriptionType" descriptionTypeRef="http://pbcore.org/vocabularies/pbcoreDescription/descriptionType#table-of-contents" annotation="Parts List"/>
+	<pbcoreRightsSummary>
+		<rightsSummary/>
+	</pbcoreRightsSummary>
+	<pbcoreAnnotation annotationType="Notes"/>
+	<pbcoreIdentifier source="Rock and Roll Hall of Fame and Museum">test-datastream</pbcoreIdentifier>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/physical_instantiation_solr.xml
+++ b/spec/fixtures/physical_instantiation_solr.xml
@@ -1,114 +1,113 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hash>
-  <barcode-teim type="array">
-    <barcode-teim>barcode</barcode-teim>
-  </barcode-teim>
-  <barcode-ssm type="array">
-    <barcode-ssm>barcode</barcode-ssm>
-  </barcode-ssm>
-  <instantiationDate-dtsim type="array">
-    <instantiationDate-dtsim>2012-11-01T00:00:00Z</instantiationDate-dtsim>
-  </instantiationDate-dtsim>
-  <instantiationDate-ssm type="array">
-    <instantiationDate-ssm>2012-11-01</instantiationDate-ssm>
-  </instantiationDate-ssm>
-  <instantiationPhysical-teim type="array">
-    <instantiationPhysical-teim>format</instantiationPhysical-teim>
-  </instantiationPhysical-teim>
-  <instantiationPhysical-ssm type="array">
-    <instantiationPhysical-ssm>format</instantiationPhysical-ssm>
-  </instantiationPhysical-ssm>
-  <instantiationPhysical-sim type="array">
-    <instantiationPhysical-sim>format</instantiationPhysical-sim>
-  </instantiationPhysical-sim>
-  <instantiationStandard-ssm type="array">
-    <instantiationStandard-ssm>standard</instantiationStandard-ssm>
-  </instantiationStandard-ssm>
-  <instantiationLocation-ssm type="array">
-    <instantiationLocation-ssm>location</instantiationLocation-ssm>
-  </instantiationLocation-ssm>
-  <instantiationGenerations-ssm type="array">
-    <instantiationGenerations-ssm>generation</instantiationGenerations-ssm>
-  </instantiationGenerations-ssm>
-  <instantiationColors-ssm type="array">
-    <instantiationColors-ssm>colors</instantiationColors-ssm>
-  </instantiationColors-ssm>
-  <instantiationMediaType-ssm type="array">
-    <instantiationMediaType-ssm>media_type</instantiationMediaType-ssm>
-  </instantiationMediaType-ssm>
-  <instantiationMediaType-sim type="array">
-    <instantiationMediaType-sim>media_type</instantiationMediaType-sim>
-  </instantiationMediaType-sim>
-  <instantiationLanguage-teim type="array">
-    <instantiationLanguage-teim>language</instantiationLanguage-teim>
-  </instantiationLanguage-teim>
-  <instantiationRights-rightsSummary-ssm type="array">
-    <instantiationRights-rightsSummary-ssm>rights_summary</instantiationRights-rightsSummary-ssm>
-  </instantiationRights-rightsSummary-ssm>
-  <instantiationRights-0-rightsSummary-ssm type="array">
-    <instantiationRights-0-rightsSummary-ssm>rights_summary</instantiationRights-0-rightsSummary-ssm>
-  </instantiationRights-0-rightsSummary-ssm>
-  <inst-cond-note-ssm type="array">
-    <inst-cond-note-ssm>condition_note</inst-cond-note-ssm>
-  </inst-cond-note-ssm>
-  <inst-clean-note-ssm type="array">
-    <inst-clean-note-ssm>cleaning_note</inst-clean-note-ssm>
-  </inst-clean-note-ssm>
-  <condition-note-teim type="array">
-    <condition-note-teim>condition_note</condition-note-teim>
-  </condition-note-teim>
-  <condition-note-ssm type="array">
-    <condition-note-ssm>condition_note</condition-note-ssm>
-  </condition-note-ssm>
-  <cleaning-note-teim type="array">
-    <cleaning-note-teim>cleaning_note</cleaning-note-teim>
-  </cleaning-note-teim>
-  <cleaning-note-ssm type="array">
-    <cleaning-note-ssm>cleaning_note</cleaning-note-ssm>
-  </cleaning-note-ssm>
-  <location-ssm type="array">
-    <location-ssm>location</location-ssm>
-  </location-ssm>
-  <date-dtsim type="array">
-    <date-dtsim>2012-11-01T00:00:00Z</date-dtsim>
-  </date-dtsim>
-  <date-ssm type="array">
-    <date-ssm>2012-11-01</date-ssm>
-  </date-ssm>
-  <generation-ssm type="array">
-    <generation-ssm>generation</generation-ssm>
-  </generation-ssm>
-  <media-type-ssm type="array">
-    <media-type-ssm>media_type</media-type-ssm>
-  </media-type-ssm>
-  <media-type-sim type="array">
-    <media-type-sim>media_type</media-type-sim>
-  </media-type-sim>
-  <format-teim type="array">
-    <format-teim>format</format-teim>
-  </format-teim>
-  <format-ssm type="array">
-    <format-ssm>format</format-ssm>
-  </format-ssm>
-  <format-sim type="array">
-    <format-sim>format</format-sim>
-  </format-sim>
-  <colors-ssm type="array">
-    <colors-ssm>colors</colors-ssm>
-  </colors-ssm>
-  <rights-summary-ssm type="array">
-    <rights-summary-ssm>rights_summary</rights-summary-ssm>
-  </rights-summary-ssm>
-  <condition-ssm type="array">
-    <condition-ssm>condition_note</condition-ssm>
-  </condition-ssm>
-  <cleaning-ssm type="array">
-    <cleaning-ssm>cleaning_note</cleaning-ssm>
-  </cleaning-ssm>
-  <standard-ssm type="array">
-    <standard-ssm>standard</standard-ssm>
-  </standard-ssm>
-  <language-teim type="array">
-    <language-teim>language</language-teim>
-  </language-teim>
-</hash>
+ <test2--barcode-teim type="array">
+   <test2--barcode-teim>barcode</test2--barcode-teim>
+ </test2--barcode-teim>
+ <test2--barcode-ssm type="array">
+   <test2--barcode-ssm>barcode</test2--barcode-ssm>
+ </test2--barcode-ssm>
+ <test2--instantiationDate-dtsim type="array">
+   <test2--instantiationDate-dtsim>2012-11-01T00:00:00Z</test2--instantiationDate-dtsim>
+ </test2--instantiationDate-dtsim>
+ <test2--instantiationDate-ssm type="array">
+   <test2--instantiationDate-ssm>2012-11-01</test2--instantiationDate-ssm>
+ </test2--instantiationDate-ssm>
+ <test2--instantiationPhysical-teim type="array">
+   <test2--instantiationPhysical-teim>format</test2--instantiationPhysical-teim>
+ </test2--instantiationPhysical-teim>
+ <test2--instantiationPhysical-ssm type="array">
+   <test2--instantiationPhysical-ssm>format</test2--instantiationPhysical-ssm>
+ </test2--instantiationPhysical-ssm>
+ <test2--instantiationPhysical-sim type="array">
+   <test2--instantiationPhysical-sim>format</test2--instantiationPhysical-sim>
+ </test2--instantiationPhysical-sim>
+ <test2--instantiationStandard-ssm type="array">
+   <test2--instantiationStandard-ssm>standard</test2--instantiationStandard-ssm>
+ </test2--instantiationStandard-ssm>
+ <test2--instantiationLocation-ssm type="array">
+   <test2--instantiationLocation-ssm>location</test2--instantiationLocation-ssm>
+ </test2--instantiationLocation-ssm>
+ <test2--instantiationGenerations-ssm type="array">
+   <test2--instantiationGenerations-ssm>generation</test2--instantiationGenerations-ssm>
+ </test2--instantiationGenerations-ssm>
+ <test2--instantiationColors-ssm type="array">
+   <test2--instantiationColors-ssm>colors</test2--instantiationColors-ssm>
+ </test2--instantiationColors-ssm>
+ <test2--instantiationMediaType-ssm type="array">
+   <test2--instantiationMediaType-ssm>media_type</test2--instantiationMediaType-ssm>
+ </test2--instantiationMediaType-ssm>
+ <test2--instantiationMediaType-sim type="array">
+   <test2--instantiationMediaType-sim>media_type</test2--instantiationMediaType-sim>
+ </test2--instantiationMediaType-sim>
+ <test2--instantiationLanguage-teim type="array">
+   <test2--instantiationLanguage-teim>language</test2--instantiationLanguage-teim>
+ </test2--instantiationLanguage-teim>
+ <test2--instantiationRights-rightsSummary-ssm type="array">
+   <test2--instantiationRights-rightsSummary-ssm>rights_summary</test2--instantiationRights-rightsSummary-ssm>
+ </test2--instantiationRights-rightsSummary-ssm>
+ <test2--instantiationRights-0-rightsSummary-ssm type="array">
+   <test2--instantiationRights-0-rightsSummary-ssm>rights_summary</test2--instantiationRights-0-rightsSummary-ssm>
+ </test2--instantiationRights-0-rightsSummary-ssm>
+ <test2--inst-cond-note-ssm type="array">
+   <test2--inst-cond-note-ssm>condition_note</test2--inst-cond-note-ssm>
+ </test2--inst-cond-note-ssm>
+ <test2--inst-clean-note-ssm type="array">
+   <test2--inst-clean-note-ssm>cleaning_note</test2--inst-clean-note-ssm>
+ </test2--inst-clean-note-ssm>
+ <test2--condition-note-teim type="array">
+   <test2--condition-note-teim>condition_note</test2--condition-note-teim>
+ </test2--condition-note-teim>
+ <test2--condition-note-ssm type="array">
+   <test2--condition-note-ssm>condition_note</test2--condition-note-ssm>
+ </test2--condition-note-ssm>
+ <test2--cleaning-note-teim type="array">
+   <test2--cleaning-note-teim>cleaning_note</test2--cleaning-note-teim>
+ </test2--cleaning-note-teim>
+ <test2--cleaning-note-ssm type="array">
+   <test2--cleaning-note-ssm>cleaning_note</test2--cleaning-note-ssm>
+ </test2--cleaning-note-ssm>
+ <test2--location-ssm type="array">
+   <test2--location-ssm>location</test2--location-ssm>
+ </test2--location-ssm>
+ <test2--date-dtsim type="array">
+   <test2--date-dtsim>2012-11-01T00:00:00Z</test2--date-dtsim>
+ </test2--date-dtsim>
+ <test2--date-ssm type="array">
+   <test2--date-ssm>2012-11-01</test2--date-ssm>
+ </test2--date-ssm>
+ <test2--generation-ssm type="array">
+   <test2--generation-ssm>generation</test2--generation-ssm>
+ </test2--generation-ssm>
+ <test2--media-type-ssm type="array">
+   <test2--media-type-ssm>media_type</test2--media-type-ssm>
+ </test2--media-type-ssm>
+ <test2--media-type-sim type="array">
+   <test2--media-type-sim>media_type</test2--media-type-sim>
+ </test2--media-type-sim>
+ <test2--format-teim type="array">
+   <test2--format-teim>format</test2--format-teim>
+ </test2--format-teim>
+ <test2--format-ssm type="array">
+   <test2--format-ssm>format</test2--format-ssm>
+ </test2--format-ssm>
+ <test2--format-sim type="array">
+   <test2--format-sim>format</test2--format-sim>
+ </test2--format-sim>
+ <test2--colors-ssm type="array">
+   <test2--colors-ssm>colors</test2--colors-ssm>
+ </test2--colors-ssm>
+ <test2--rights-summary-ssm type="array">
+   <test2--rights-summary-ssm>rights_summary</test2--rights-summary-ssm>
+ </test2--rights-summary-ssm>
+ <test2--condition-ssm type="array">
+   <test2--condition-ssm>condition_note</test2--condition-ssm>
+ </test2--condition-ssm>
+ <test2--cleaning-ssm type="array">
+   <test2--cleaning-ssm>cleaning_note</test2--cleaning-ssm>
+ </test2--cleaning-ssm>
+ <test2--standard-ssm type="array">
+   <test2--standard-ssm>standard</test2--standard-ssm>
+ </test2--standard-ssm>
+ <test2--language-teim type="array">
+   <test2--language-teim>language</test2--language-teim>
+ </test2--language-teim>

--- a/spec/instantiation_spec.rb
+++ b/spec/instantiation_spec.rb
@@ -3,15 +3,15 @@ require "spec_helper"
 describe HydraPbcore::Datastream::Instantiation do
 
   before(:each) do
-    @digital  = HydraPbcore::Datastream::Instantiation.new(nil, nil)
+    @digital  = HydraPbcore::Datastream::Instantiation.new(nil, 'test1')
     @digital.define :digital
-    @physical = HydraPbcore::Datastream::Instantiation.new(nil, nil)
+    @physical = HydraPbcore::Datastream::Instantiation.new(nil, 'test2')
     @physical.define :physical
   end
 
   describe "::xml_template" do
     it "should have a blank default xml template" do
-      HydraPbcore::Datastream::Instantiation.xml_template.text.should be_empty
+      expect(HydraPbcore::Datastream::Instantiation.xml_template.text).to eq ''
     end
   end
 
@@ -61,19 +61,19 @@ describe HydraPbcore::Datastream::Instantiation do
       ].each do |pointer|
         test_val = random_string
         @digital.update_indexed_attributes( {pointer=>{"0"=>test_val}} )
-        @digital.get_values(pointer).first.should == test_val
-        @digital.get_values(pointer).length.should == 1
+        expect(@digital.get_values(pointer).first).to eq test_val
+        expect(@digital.get_values(pointer).length).to eq 1
       end
     end
 
     it "should have default values for fields" do
-      @digital.media_type.first.should == "Moving image"
-      @digital.colors.first.should == "Color"
+      expect(@digital.media_type.first).to eq "Moving image"
+      expect(@digital.colors.first).to eq "Color"
     end
 
     it "should have a file format and no format" do
-      @digital.file_format.should == [""]
-      @digital.format.should      == []
+      expect(@digital.file_format).to eq [""]
+      expect(@digital.format).to eq []
     end
 
     it "should match an exemplar with all fields shown" do
@@ -163,15 +163,16 @@ describe HydraPbcore::Datastream::Instantiation do
       end
 
       it "should display dates as they were entered" do
-        @digital.to_solr["date_ssm"].should == ["2012-11-01"]
+        expect(@digital.to_solr["test1__date_ssm"]).to eq ["2012-11-01"]
       end
 
       it "should have dates converted to ISO 8601" do
-        @digital.to_solr["date_dtsim"].should == ["2012-11-01T00:00:00Z"]
+        expect(@digital.to_solr["test1__date_dtsim"]).to eq ["2012-11-01T00:00:00Z"]
       end
 
+      # TODO: Weak test. Any non-existent key would pass.
       it "should not index dates as text" do
-        @digital.to_solr["date_t"].should be_nil
+        expect(@digital.to_solr["test1__date_t"]).to eq nil
       end
     end
   
@@ -195,19 +196,19 @@ describe HydraPbcore::Datastream::Instantiation do
       ].each do |pointer|
         test_val = random_string
         @physical.update_indexed_attributes( {pointer=>{"0"=>test_val}} )
-        @physical.get_values(pointer).first.should == test_val
-        @physical.get_values(pointer).length.should == 1
+        expect(@physical.get_values(pointer).first).to eq test_val
+        expect(@physical.get_values(pointer).length).to eq 1
       end
     end
 
     it "should have default values for fields" do
-      @physical.media_type.first.should == "Moving image"
-      @physical.colors.first.should == "Color"
+      expect(@physical.media_type.first).to eq "Moving image"
+      expect(@physical.colors.first).to eq "Color"
     end
 
     it "should have a format and no file format" do
-      @physical.file_format.should == []
-      @physical.format.should      == [""]
+      expect(@physical.file_format).to eq []
+      expect(@physical.format).to eq [""]
     end
 
     it "should match an exmplar with all fields shown" do
@@ -245,15 +246,16 @@ describe HydraPbcore::Datastream::Instantiation do
       end
 
       it "should display dates as they were entered" do
-        @physical.to_solr["date_ssm"].should == ["2012-11-01"]
+        expect(@physical.to_solr["test2__date_ssm"]).to eq ["2012-11-01"]
       end
 
       it "should have dates converted to ISO 8601" do
-        @physical.to_solr["date_dtsim"].should == ["2012-11-01T00:00:00Z"]
+        expect(@physical.to_solr["test2__date_dtsim"]).to eq ["2012-11-01T00:00:00Z"]
       end
 
+      # TODO: Weak test. Any non-existent key would pass.
       it "should not index dates as text" do
-        @physical.to_solr["date_t"].should be_nil
+        expect(@physical.to_solr["test2__date_t"]).to eq nil
       end
     end
 
@@ -262,31 +264,31 @@ describe HydraPbcore::Datastream::Instantiation do
     describe "solrization of dates" do
 
     before :each do
-      @ds = HydraPbcore::Datastream::Instantiation.new(nil, nil)
+      @ds = HydraPbcore::Datastream::Instantiation.new(nil, 'test1')
     end
 
     it "creates dateable and displayable fields for complete dates" do
       @ds.date = "1898-11-12"
-      @ds.to_solr["date_dtsim"].should == ["1898-11-12T00:00:00Z"]
-      @ds.to_solr["date_ssm"].should == ["1898-11-12"]
+      expect(@ds.to_solr["test1__date_dtsim"]).to eq ["1898-11-12T00:00:00Z"]
+      expect(@ds.to_solr["test1__date_ssm"]).to eq ["1898-11-12"]
     end
 
     it "creates only displayable fields for dates without day" do
       @ds.date = "1911-07"
-      @ds.to_solr["date_dtsim"].should be_empty
-      @ds.to_solr["date_ssm"].should == ["1911-07"]
+      expect(@ds.to_solr["test1__date_dtsim"]).to eq []
+      expect(@ds.to_solr["test1__date_ssm"]).to eq ["1911-07"]
     end
 
     it "creates only displayable fields for dates without day and month" do
       @ds.date = "1945"
-      @ds.to_solr["date_dtsim"].should be_empty
-      @ds.to_solr["date_ssm"].should == ["1945"]
+      expect(@ds.to_solr["test1__date_dtsim"]).to eq []
+      expect(@ds.to_solr["test1__date_ssm"]).to eq ["1945"]
     end
 
     it "creates only displayable for non-parseable dates" do
       @ds.date = "crap"
-      @ds.to_solr["date_dtsim"].should be_empty
-      @ds.to_solr["date_ssm"].should == ["crap"]
+      expect(@ds.to_solr["test1__date_dtsim"]).to eq []
+      expect(@ds.to_solr["test1__date_ssm"]).to eq ["crap"]
     end
 
   end 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 require "hydra-pbcore"
 require 'rspec/matchers'
 require "equivalent-xml"
+require 'equivalent-xml/rspec_matchers'
 require "pry" unless ENV['TRAVIS']
 
 RSpec.configure do |config|


### PR DESCRIPTION
…hange

as a result.

* Pins ActiveFedora to ~> 8, the latest version that still uses Fedora 3.
  Updating to use ActiveFedora ~> 9.1 will require some work.
* Explicitly requires rspec matchers for equivalent-xml gem, which is required
  for compatibility with RSpec ~> 3.
* Updates more specs to RSpec ~> 3 syntax (still maybe not all).
* Updates datastreams in spec to have a dsid, as is now required by AF,
  and updates exemplar fixtures to include the dsid's specified in tests.
  NOTE: I'm not a fan of tight coupling between fixtures and tests.
* Fixes tests against .valid? checks on datastreams.